### PR TITLE
Send experiment config in start_experiment request

### DIFF
--- a/crates/heat-sdk/src/http_schemas.rs
+++ b/crates/heat-sdk/src/http_schemas.rs
@@ -10,3 +10,8 @@ pub enum EndExperimentSchema {
     Success,
     Fail(String),
 }
+
+#[derive(Serialize)]
+pub struct StartExperimentSchema {
+    pub config: serde_json::Value,
+}

--- a/examples/guide/src/training.rs
+++ b/examples/guide/src/training.rs
@@ -99,7 +99,7 @@ pub fn train<B: AutodiffBackend>(
         .build(SamplerDataset::new(MnistDataset::test(), 20));
 
     client
-        .start_experiment()
+        .start_experiment(&config)
         .expect("Experiment should be started");
 
     let recorder =


### PR DESCRIPTION
This changes the client's `start_experiment` method to take in a serializable config parameter to send to the Heat API.

This closes #15 