### PR TITLE
refactor: centralize project state in ProjectContext

### DIFF
--- a/crates/burn-central-cli/src/commands/me.rs
+++ b/crates/burn-central-cli/src/commands/me.rs
@@ -2,16 +2,16 @@ use crate::app_config::Environment;
 use crate::commands::login::get_client_and_login_if_needed;
 use crate::context::CliContext;
 
-pub fn handle_command(mut context: CliContext) {
+pub fn handle_command(mut context: CliContext) -> anyhow::Result<()> {
     context.terminal().command_title("User Information");
 
     let client = get_client_and_login_if_needed(&mut context);
     if let Err(e) = client {
         context.terminal().cancel_finalize(&format!(
             "Failed to connect to the server: {}. Please run 'cargo run -- login' to authenticate.",
-            e
+            &e
         ));
-        return;
+        anyhow::bail!(e);
     }
     let client = client.unwrap();
 
@@ -21,7 +21,7 @@ pub fn handle_command(mut context: CliContext) {
             context
                 .terminal()
                 .cancel_finalize(&format!("Failed to retrieve user information: {}", e));
-            return;
+            anyhow::bail!(e);
         }
     };
 
@@ -47,4 +47,6 @@ pub fn handle_command(mut context: CliContext) {
     context
         .terminal()
         .finalize("User information retrieved successfully.");
+
+    Ok(())
 }

--- a/crates/burn-central-cli/src/commands/mod.rs
+++ b/crates/burn-central-cli/src/commands/mod.rs
@@ -1,5 +1,6 @@
 use crate::commands::init::prompt_init;
 use crate::commands::training::TrainingArgs;
+use crate::entity::projects::ProjectContext;
 use crate::print_info;
 use crate::{commands::login::get_client_and_login_if_needed, context::CliContext};
 pub mod init;
@@ -11,13 +12,14 @@ pub mod training;
 pub mod unlink;
 
 pub fn default_command(mut context: CliContext) -> anyhow::Result<()> {
-    let project_loaded = context.load_project().is_ok();
+    let mut project = ProjectContext::discover(context.environment())?;
+    let project_loaded = project.get_project().is_some();
 
     let client = get_client_and_login_if_needed(&mut context)?;
 
     if !project_loaded {
         print_info!("No project loaded. Running initialization sequence.");
-        prompt_init(&context, &client)?;
+        prompt_init(&context, &client, &mut project)?;
     } else {
         training::handle_command(TrainingArgs::default(), context)?;
     }

--- a/crates/burn-central-cli/src/commands/unlink.rs
+++ b/crates/burn-central-cli/src/commands/unlink.rs
@@ -1,6 +1,15 @@
-use crate::context::CliContext;
+use crate::{context::CliContext, entity::projects::ProjectContext};
 
-pub fn handle_command(context: CliContext) {
+pub fn handle_command(context: CliContext) -> anyhow::Result<()> {
+    let project = ProjectContext::discover(context.environment())?;
+
+    if project.get_project().is_none() {
+        context
+            .terminal()
+            .cancel_finalize("No burn central project is linked to this package.");
+        return Ok(());
+    }
+
     context.terminal().command_title("Unlink");
 
     let confirm_value = context
@@ -9,15 +18,18 @@ pub fn handle_command(context: CliContext) {
         .unwrap();
 
     if confirm_value {
-        match context.burn_dir().unlink_project() {
+        match project.burn_dir().unlink_project() {
             Ok(_) => context.terminal().finalize("Project unlinked"),
             Err(e) => {
                 context
                     .terminal()
                     .cancel_finalize(&format!("Failed to unlink project: {}", e));
+                anyhow::bail!(e);
             }
         }
     } else {
         context.terminal().cancel_finalize("Cancelled");
     }
+
+    Ok(())
 }

--- a/crates/burn-central-cli/src/entity/projects/burn_dir/mod.rs
+++ b/crates/burn-central-cli/src/entity/projects/burn_dir/mod.rs
@@ -50,8 +50,16 @@ impl BurnDir {
         cache.save(&self.root)
     }
 
-    pub fn load_project(&self) -> io::Result<BurnCentralProject> {
+    pub fn load_project(&self) -> io::Result<Option<BurnCentralProject>> {
         BurnCentralProject::load(&self.root)
+            .map(Some)
+            .or_else(|err| {
+                if err.kind() == io::ErrorKind::NotFound {
+                    Ok(None)
+                } else {
+                    Err(err)
+                }
+            })
     }
 
     pub fn save_project(&self, project: &BurnCentralProject) -> io::Result<()> {

--- a/crates/burn-central-cli/src/entity/projects/burn_dir/project.rs
+++ b/crates/burn-central-cli/src/entity/projects/burn_dir/project.rs
@@ -1,4 +1,4 @@
-﻿use serde::{Deserialize, Serialize};
+use serde::{Deserialize, Serialize};
 use std::path::Path;
 use std::{fs, io};
 

--- a/crates/burn-central-cli/src/entity/projects/mod.rs
+++ b/crates/burn-central-cli/src/entity/projects/mod.rs
@@ -1,7 +1,11 @@
 use std::path::{Path, PathBuf};
 
+use anyhow::Context;
+
 use crate::app_config::Environment;
 use crate::entity::projects::burn_dir::{BurnDir, project::BurnCentralProject};
+use crate::generation::GeneratedCrate;
+use crate::tools::cargo;
 
 pub mod burn_dir;
 pub mod project_path;
@@ -13,10 +17,23 @@ pub struct ProjectContext {
     pub build_profile: String,
     pub burn_dir: BurnDir,
     pub project: Option<BurnCentralProject>,
+    pub metadata: cargo_metadata::Metadata,
 }
 
 impl ProjectContext {
-    pub fn load_from_manifest(manifest_path: &Path, environment: Environment) -> Self {
+    pub fn discover(environment: Environment) -> anyhow::Result<Self> {
+        let manifest_path = cargo::try_locate_manifest().ok_or_else(|| {
+            anyhow::anyhow!(
+                "Failed to locate Cargo.toml in the current directory or any parent directories"
+            )
+        })?;
+        Self::load_from_manifest(&manifest_path, environment)
+    }
+
+    pub fn load_from_manifest(
+        manifest_path: &Path,
+        environment: Environment,
+    ) -> anyhow::Result<Self> {
         // assert that the manifest path is a file
         assert!(manifest_path.is_file());
         assert!(manifest_path.ends_with("Cargo.toml"));
@@ -38,20 +55,64 @@ impl ProjectContext {
         let burn_dir = BurnDir::new(&user_crate_dir, environment);
         burn_dir
             .init()
-            .expect("Burn directory should be initialized");
+            .with_context(|| "Burn directory should be initialized")?;
 
-        Self {
+        let metadata = cargo_metadata::MetadataCommand::new()
+            .manifest_path(manifest_path)
+            .exec()
+            .with_context(|| "Failed to load cargo metadata")?;
+
+        let project = burn_dir
+            .load_project()
+            .with_context(|| "Failed to load project metadata from burn directory")?;
+
+        Ok(Self {
             user_crate_name,
             user_crate_dir,
             generated_crate_name,
             build_profile: "release".to_string(),
             burn_dir,
-            project: None,
-        }
+            project,
+            metadata,
+        })
     }
 
-    pub fn load_project(&mut self) -> anyhow::Result<()> {
-        self.project = Some(self.burn_dir.load_project()?);
+    pub fn get_project(&self) -> Option<&BurnCentralProject> {
+        self.project.as_ref()
+    }
+
+    pub fn save_project(&mut self, project: &BurnCentralProject) -> anyhow::Result<()> {
+        self.burn_dir
+            .save_project(project)
+            .with_context(|| "Failed to save project metadata to burn directory")?;
+        self.project = Some(project.clone());
         Ok(())
+    }
+
+    pub fn get_workspace_root(&self) -> PathBuf {
+        self.metadata.workspace_root.clone().into_std_path_buf()
+    }
+
+    pub fn save_crate(&self, generated_crate: GeneratedCrate) -> anyhow::Result<()> {
+        let mut cache = self.burn_dir.load_cache()?;
+        let name = generated_crate.name();
+        generated_crate
+            .write_to_burn_dir(&self.burn_dir, &mut cache)
+            .with_context(|| {
+                format!(
+                    "Failed to save generated crate '{}' to burn directory",
+                    name
+                )
+            })?;
+        self.burn_dir.save_cache(&cache)?;
+        Ok(())
+    }
+
+    pub fn burn_dir(&self) -> &BurnDir {
+        &self.burn_dir
+    }
+
+    pub fn cwd(&self) -> &Path {
+        &self.user_crate_dir
     }
 }

--- a/crates/burn-central-runtime/Cargo.toml
+++ b/crates/burn-central-runtime/Cargo.toml
@@ -9,7 +9,6 @@ rust-version.workspace = true
 [features]
 default = []
 ndarray-stub = ["burn/ndarray"]
-cli = ["dep:clap"]
 
 [dependencies]
 anyhow = "1.0.98"
@@ -26,7 +25,7 @@ derive_more = { workspace = true, features = [
     "display",
     "unwrap",
 ] }
-clap = { workspace = true, features = ["derive"], optional = true }
+clap = { workspace = true, features = ["derive"] }
 log = { workspace = true, features = ["std"] }
 env_logger = { workspace = true }
 serde_json = { workspace = true }

--- a/crates/burn-central-runtime/src/lib.rs
+++ b/crates/burn-central-runtime/src/lib.rs
@@ -8,7 +8,6 @@ mod routine;
 mod type_name;
 mod types;
 
-#[cfg(feature = "cli")]
 pub mod cli;
 
 pub use error::RuntimeError;


### PR DESCRIPTION
Remove project metadata from CliContext and move project discovery, loading, saving, and crate-related helpers into ProjectContext.