### PR TITLE
Feat: Migrate code to respect the new version of burn

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -446,7 +446,6 @@ name = "burn-central-fleet"
 version = "0.6.0"
 dependencies = [
  "arc-swap",
- "burn",
  "burn-central-artifact",
  "burn-central-client",
  "burn-central-inference",

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -331,7 +331,7 @@ checksum = "5d20789868f4b01b2f2caec9f5c4e0213b41e3e5702a50157d699ae31ced2fcb"
 [[package]]
 name = "burn"
 version = "0.22.0-pre.1"
-source = "git+https://github.com/tracel-ai/burn?rev=dbf03c516bac61efa3186ba9cafdb92ddf294021#dbf03c516bac61efa3186ba9cafdb92ddf294021"
+source = "git+https://github.com/tracel-ai/burn?rev=924d5d9ee9f87c411a103e1178a9baeb3e6c3f1a#924d5d9ee9f87c411a103e1178a9baeb3e6c3f1a"
 dependencies = [
  "burn-autodiff",
  "burn-core",
@@ -344,7 +344,7 @@ dependencies = [
 [[package]]
 name = "burn-autodiff"
 version = "0.22.0-pre.1"
-source = "git+https://github.com/tracel-ai/burn?rev=dbf03c516bac61efa3186ba9cafdb92ddf294021#dbf03c516bac61efa3186ba9cafdb92ddf294021"
+source = "git+https://github.com/tracel-ai/burn?rev=924d5d9ee9f87c411a103e1178a9baeb3e6c3f1a#924d5d9ee9f87c411a103e1178a9baeb3e6c3f1a"
 dependencies = [
  "burn-backend",
  "burn-std",
@@ -361,7 +361,7 @@ dependencies = [
 [[package]]
 name = "burn-backend"
 version = "0.22.0-pre.1"
-source = "git+https://github.com/tracel-ai/burn?rev=dbf03c516bac61efa3186ba9cafdb92ddf294021#dbf03c516bac61efa3186ba9cafdb92ddf294021"
+source = "git+https://github.com/tracel-ai/burn?rev=924d5d9ee9f87c411a103e1178a9baeb3e6c3f1a#924d5d9ee9f87c411a103e1178a9baeb3e6c3f1a"
 dependencies = [
  "burn-std",
  "bytemuck",
@@ -515,7 +515,7 @@ dependencies = [
 [[package]]
 name = "burn-core"
 version = "0.22.0-pre.1"
-source = "git+https://github.com/tracel-ai/burn?rev=dbf03c516bac61efa3186ba9cafdb92ddf294021#dbf03c516bac61efa3186ba9cafdb92ddf294021"
+source = "git+https://github.com/tracel-ai/burn?rev=924d5d9ee9f87c411a103e1178a9baeb3e6c3f1a#924d5d9ee9f87c411a103e1178a9baeb3e6c3f1a"
 dependencies = [
  "ahash",
  "bincode",
@@ -544,7 +544,7 @@ dependencies = [
 [[package]]
 name = "burn-cpu"
 version = "0.22.0-pre.1"
-source = "git+https://github.com/tracel-ai/burn?rev=dbf03c516bac61efa3186ba9cafdb92ddf294021#dbf03c516bac61efa3186ba9cafdb92ddf294021"
+source = "git+https://github.com/tracel-ai/burn?rev=924d5d9ee9f87c411a103e1178a9baeb3e6c3f1a#924d5d9ee9f87c411a103e1178a9baeb3e6c3f1a"
 dependencies = [
  "burn-backend",
  "burn-cubecl",
@@ -554,7 +554,7 @@ dependencies = [
 [[package]]
 name = "burn-cubecl"
 version = "0.22.0-pre.1"
-source = "git+https://github.com/tracel-ai/burn?rev=dbf03c516bac61efa3186ba9cafdb92ddf294021#dbf03c516bac61efa3186ba9cafdb92ddf294021"
+source = "git+https://github.com/tracel-ai/burn?rev=924d5d9ee9f87c411a103e1178a9baeb3e6c3f1a#924d5d9ee9f87c411a103e1178a9baeb3e6c3f1a"
 dependencies = [
  "burn-backend",
  "burn-cubecl-fusion",
@@ -573,7 +573,7 @@ dependencies = [
 [[package]]
 name = "burn-cubecl-fusion"
 version = "0.22.0-pre.1"
-source = "git+https://github.com/tracel-ai/burn?rev=dbf03c516bac61efa3186ba9cafdb92ddf294021#dbf03c516bac61efa3186ba9cafdb92ddf294021"
+source = "git+https://github.com/tracel-ai/burn?rev=924d5d9ee9f87c411a103e1178a9baeb3e6c3f1a#924d5d9ee9f87c411a103e1178a9baeb3e6c3f1a"
 dependencies = [
  "burn-backend",
  "burn-fusion",
@@ -590,7 +590,7 @@ dependencies = [
 [[package]]
 name = "burn-cuda"
 version = "0.22.0-pre.1"
-source = "git+https://github.com/tracel-ai/burn?rev=dbf03c516bac61efa3186ba9cafdb92ddf294021#dbf03c516bac61efa3186ba9cafdb92ddf294021"
+source = "git+https://github.com/tracel-ai/burn?rev=924d5d9ee9f87c411a103e1178a9baeb3e6c3f1a#924d5d9ee9f87c411a103e1178a9baeb3e6c3f1a"
 dependencies = [
  "burn-backend",
  "burn-cubecl",
@@ -600,7 +600,7 @@ dependencies = [
 [[package]]
 name = "burn-dataset"
 version = "0.22.0-pre.1"
-source = "git+https://github.com/tracel-ai/burn?rev=dbf03c516bac61efa3186ba9cafdb92ddf294021#dbf03c516bac61efa3186ba9cafdb92ddf294021"
+source = "git+https://github.com/tracel-ai/burn?rev=924d5d9ee9f87c411a103e1178a9baeb3e6c3f1a#924d5d9ee9f87c411a103e1178a9baeb3e6c3f1a"
 dependencies = [
  "csv",
  "derive-new",
@@ -618,7 +618,7 @@ dependencies = [
 [[package]]
 name = "burn-derive"
 version = "0.22.0-pre.1"
-source = "git+https://github.com/tracel-ai/burn?rev=dbf03c516bac61efa3186ba9cafdb92ddf294021#dbf03c516bac61efa3186ba9cafdb92ddf294021"
+source = "git+https://github.com/tracel-ai/burn?rev=924d5d9ee9f87c411a103e1178a9baeb3e6c3f1a#924d5d9ee9f87c411a103e1178a9baeb3e6c3f1a"
 dependencies = [
  "derive-new",
  "proc-macro2",
@@ -629,7 +629,7 @@ dependencies = [
 [[package]]
 name = "burn-dispatch"
 version = "0.22.0-pre.1"
-source = "git+https://github.com/tracel-ai/burn?rev=dbf03c516bac61efa3186ba9cafdb92ddf294021#dbf03c516bac61efa3186ba9cafdb92ddf294021"
+source = "git+https://github.com/tracel-ai/burn?rev=924d5d9ee9f87c411a103e1178a9baeb3e6c3f1a#924d5d9ee9f87c411a103e1178a9baeb3e6c3f1a"
 dependencies = [
  "burn-autodiff",
  "burn-backend",
@@ -646,7 +646,7 @@ dependencies = [
 [[package]]
 name = "burn-flex"
 version = "0.22.0-pre.1"
-source = "git+https://github.com/tracel-ai/burn?rev=dbf03c516bac61efa3186ba9cafdb92ddf294021#dbf03c516bac61efa3186ba9cafdb92ddf294021"
+source = "git+https://github.com/tracel-ai/burn?rev=924d5d9ee9f87c411a103e1178a9baeb3e6c3f1a#924d5d9ee9f87c411a103e1178a9baeb3e6c3f1a"
 dependencies = [
  "aligned-vec",
  "burn-backend",
@@ -664,7 +664,7 @@ dependencies = [
 [[package]]
 name = "burn-fusion"
 version = "0.22.0-pre.1"
-source = "git+https://github.com/tracel-ai/burn?rev=dbf03c516bac61efa3186ba9cafdb92ddf294021#dbf03c516bac61efa3186ba9cafdb92ddf294021"
+source = "git+https://github.com/tracel-ai/burn?rev=924d5d9ee9f87c411a103e1178a9baeb3e6c3f1a#924d5d9ee9f87c411a103e1178a9baeb3e6c3f1a"
 dependencies = [
  "burn-backend",
  "burn-ir",
@@ -681,7 +681,7 @@ dependencies = [
 [[package]]
 name = "burn-ir"
 version = "0.22.0-pre.1"
-source = "git+https://github.com/tracel-ai/burn?rev=dbf03c516bac61efa3186ba9cafdb92ddf294021#dbf03c516bac61efa3186ba9cafdb92ddf294021"
+source = "git+https://github.com/tracel-ai/burn?rev=924d5d9ee9f87c411a103e1178a9baeb3e6c3f1a#924d5d9ee9f87c411a103e1178a9baeb3e6c3f1a"
 dependencies = [
  "burn-backend",
  "hashbrown 0.16.1",
@@ -691,7 +691,7 @@ dependencies = [
 [[package]]
 name = "burn-ndarray"
 version = "0.22.0-pre.1"
-source = "git+https://github.com/tracel-ai/burn?rev=dbf03c516bac61efa3186ba9cafdb92ddf294021#dbf03c516bac61efa3186ba9cafdb92ddf294021"
+source = "git+https://github.com/tracel-ai/burn?rev=924d5d9ee9f87c411a103e1178a9baeb3e6c3f1a#924d5d9ee9f87c411a103e1178a9baeb3e6c3f1a"
 dependencies = [
  "atomic_float",
  "burn-autodiff",
@@ -713,7 +713,7 @@ dependencies = [
 [[package]]
 name = "burn-nn"
 version = "0.22.0-pre.1"
-source = "git+https://github.com/tracel-ai/burn?rev=dbf03c516bac61efa3186ba9cafdb92ddf294021#dbf03c516bac61efa3186ba9cafdb92ddf294021"
+source = "git+https://github.com/tracel-ai/burn?rev=924d5d9ee9f87c411a103e1178a9baeb3e6c3f1a#924d5d9ee9f87c411a103e1178a9baeb3e6c3f1a"
 dependencies = [
  "burn-core",
  "num-traits",
@@ -722,7 +722,7 @@ dependencies = [
 [[package]]
 name = "burn-optim"
 version = "0.22.0-pre.1"
-source = "git+https://github.com/tracel-ai/burn?rev=dbf03c516bac61efa3186ba9cafdb92ddf294021#dbf03c516bac61efa3186ba9cafdb92ddf294021"
+source = "git+https://github.com/tracel-ai/burn?rev=924d5d9ee9f87c411a103e1178a9baeb3e6c3f1a#924d5d9ee9f87c411a103e1178a9baeb3e6c3f1a"
 dependencies = [
  "burn-core",
  "derive-new",
@@ -735,7 +735,7 @@ dependencies = [
 [[package]]
 name = "burn-rocm"
 version = "0.22.0-pre.1"
-source = "git+https://github.com/tracel-ai/burn?rev=dbf03c516bac61efa3186ba9cafdb92ddf294021#dbf03c516bac61efa3186ba9cafdb92ddf294021"
+source = "git+https://github.com/tracel-ai/burn?rev=924d5d9ee9f87c411a103e1178a9baeb3e6c3f1a#924d5d9ee9f87c411a103e1178a9baeb3e6c3f1a"
 dependencies = [
  "burn-backend",
  "burn-cubecl",
@@ -745,7 +745,7 @@ dependencies = [
 [[package]]
 name = "burn-std"
 version = "0.22.0-pre.1"
-source = "git+https://github.com/tracel-ai/burn?rev=dbf03c516bac61efa3186ba9cafdb92ddf294021#dbf03c516bac61efa3186ba9cafdb92ddf294021"
+source = "git+https://github.com/tracel-ai/burn?rev=924d5d9ee9f87c411a103e1178a9baeb3e6c3f1a#924d5d9ee9f87c411a103e1178a9baeb3e6c3f1a"
 dependencies = [
  "bytemuck",
  "bytes",
@@ -762,7 +762,7 @@ dependencies = [
 [[package]]
 name = "burn-tch"
 version = "0.22.0-pre.1"
-source = "git+https://github.com/tracel-ai/burn?rev=dbf03c516bac61efa3186ba9cafdb92ddf294021#dbf03c516bac61efa3186ba9cafdb92ddf294021"
+source = "git+https://github.com/tracel-ai/burn?rev=924d5d9ee9f87c411a103e1178a9baeb3e6c3f1a#924d5d9ee9f87c411a103e1178a9baeb3e6c3f1a"
 dependencies = [
  "burn-backend",
  "cc",
@@ -775,7 +775,7 @@ dependencies = [
 [[package]]
 name = "burn-tensor"
 version = "0.22.0-pre.1"
-source = "git+https://github.com/tracel-ai/burn?rev=dbf03c516bac61efa3186ba9cafdb92ddf294021#dbf03c516bac61efa3186ba9cafdb92ddf294021"
+source = "git+https://github.com/tracel-ai/burn?rev=924d5d9ee9f87c411a103e1178a9baeb3e6c3f1a#924d5d9ee9f87c411a103e1178a9baeb3e6c3f1a"
 dependencies = [
  "burn-backend",
  "burn-dispatch",
@@ -790,7 +790,7 @@ dependencies = [
 [[package]]
 name = "burn-train"
 version = "0.22.0-pre.1"
-source = "git+https://github.com/tracel-ai/burn?rev=dbf03c516bac61efa3186ba9cafdb92ddf294021#dbf03c516bac61efa3186ba9cafdb92ddf294021"
+source = "git+https://github.com/tracel-ai/burn?rev=924d5d9ee9f87c411a103e1178a9baeb3e6c3f1a#924d5d9ee9f87c411a103e1178a9baeb3e6c3f1a"
 dependencies = [
  "async-channel",
  "burn-core",
@@ -811,7 +811,7 @@ dependencies = [
 [[package]]
 name = "burn-wgpu"
 version = "0.22.0-pre.1"
-source = "git+https://github.com/tracel-ai/burn?rev=dbf03c516bac61efa3186ba9cafdb92ddf294021#dbf03c516bac61efa3186ba9cafdb92ddf294021"
+source = "git+https://github.com/tracel-ai/burn?rev=924d5d9ee9f87c411a103e1178a9baeb3e6c3f1a#924d5d9ee9f87c411a103e1178a9baeb3e6c3f1a"
 dependencies = [
  "burn-backend",
  "burn-cubecl",
@@ -3578,9 +3578,9 @@ checksum = "f8ca58f447f06ed17d5fc4043ce1b10dd205e060fb3ce5b979b8ed8e59ff3f79"
 
 [[package]]
 name = "metrics"
-version = "0.24.5"
+version = "0.24.6"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "ff56c2e7dce6bd462e3b8919986a617027481b1dcc703175b58cf9dd98a2f071"
+checksum = "89550ee9f79e88fef3119de263694973a8adb26c21d75322164fb8c493039fe2"
 dependencies = [
  "portable-atomic",
  "rapidhash",
@@ -3605,9 +3605,9 @@ dependencies = [
 
 [[package]]
 name = "metrics-util"
-version = "0.20.3"
+version = "0.20.4"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "9e56997f084e57b045edf17c3ed8ba7f9f779c670df8206dfd1c736f4c02dc4a"
+checksum = "96f8722f8562635f92f8ed992f26df0532266eb03d5202607c20c0d7e9745e13"
 dependencies = [
  "aho-corasick",
  "crossbeam-epoch",

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -140,9 +140,9 @@ dependencies = [
 
 [[package]]
 name = "arc-swap"
-version = "1.9.0"
+version = "1.9.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "a07d1f37ff60921c83bdfc7407723bdefe89b44b98a9b772f225c8f9d67141a6"
+checksum = "6a3a1fd6f75306b68087b831f025c712524bcb19aad54e557b1129cfa0a2b207"
 dependencies = [
  "rustversion",
 ]
@@ -194,9 +194,9 @@ checksum = "c08606f8c3cbf4ce6ec8e28fb0014a2c086708fe954eaa885384a6165172e7e8"
 
 [[package]]
 name = "aws-lc-rs"
-version = "1.16.2"
+version = "1.17.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "a054912289d18629dc78375ba2c3726a3afe3ff71b4edba9dedfca0e3446d1fc"
+checksum = "5ec2f1fc3ec205783a5da9a7e6c1509cc69dedf09a1949e412c1e18469326d00"
 dependencies = [
  "aws-lc-sys",
  "zeroize",
@@ -204,9 +204,9 @@ dependencies = [
 
 [[package]]
 name = "aws-lc-sys"
-version = "0.39.0"
+version = "0.41.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "1fa7e52a4c5c547c741610a2c6f123f3881e409b714cd27e6798ef020c514f0a"
+checksum = "1a2f9779ce85b93ab6170dd940ad0169b5766ff848247aff13bb788b832fe3f4"
 dependencies = [
  "cc",
  "cmake",
@@ -236,6 +236,12 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "72b3254f16251a8381aa12e40e3c4d2f0199f8c6508fbecb9d91f575e0fbb8c6"
 
 [[package]]
+name = "base64ct"
+version = "1.8.3"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "2af50177e190e07a26ab74f8b1efbfe2ef87da2116221318cb1c2e82baf7de06"
+
+[[package]]
 name = "bincode"
 version = "2.0.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -243,6 +249,26 @@ checksum = "36eaf5d7b090263e8150820482d5d93cd964a81e4019913c972f4edcc6edb740"
 dependencies = [
  "serde",
  "unty",
+]
+
+[[package]]
+name = "bindgen"
+version = "0.71.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "5f58bf3d7db68cfbac37cfc485a8d711e87e064c3d0fe0435b92f7a407f9d6b3"
+dependencies = [
+ "bitflags",
+ "cexpr",
+ "clang-sys",
+ "itertools 0.13.0",
+ "log",
+ "prettyplease",
+ "proc-macro2",
+ "quote",
+ "regex",
+ "rustc-hash 2.1.2",
+ "shlex",
+ "syn",
 ]
 
 [[package]]
@@ -262,9 +288,9 @@ checksum = "b71798fca2c1fe1086445a7258a4bc81e6e49dcd24c8d0dd9a1e57395b603f51"
 
 [[package]]
 name = "bitflags"
-version = "2.11.0"
+version = "2.11.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "843867be96c8daad0d758b57df9392b6d8d271134fce549de6ce169ff98a92af"
+checksum = "c4512299f36f043ab09a583e57bceb5a5aab7a73db1805848e8fef3c9e8c78b3"
 dependencies = [
  "serde_core",
 ]
@@ -288,6 +314,15 @@ dependencies = [
 ]
 
 [[package]]
+name = "bs58"
+version = "0.5.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "bf88ba1141d185c399bee5288d850d63b8369520c1eafc32a0430b5b6c287bf4"
+dependencies = [
+ "tinyvec",
+]
+
+[[package]]
 name = "bumpalo"
 version = "3.20.2"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -295,25 +330,21 @@ checksum = "5d20789868f4b01b2f2caec9f5c4e0213b41e3e5702a50157d699ae31ced2fcb"
 
 [[package]]
 name = "burn"
-version = "0.21.0"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "39474be398d30e08681f1f6a8ff446b1e4f1403b5cf7749649a8871fd5945f3a"
+version = "0.22.0-pre.1"
+source = "git+https://github.com/tracel-ai/burn?rev=dbf03c516bac61efa3186ba9cafdb92ddf294021#dbf03c516bac61efa3186ba9cafdb92ddf294021"
 dependencies = [
  "burn-autodiff",
  "burn-core",
- "burn-dispatch",
  "burn-ndarray",
  "burn-nn",
- "burn-optim",
  "burn-std",
  "burn-train",
 ]
 
 [[package]]
 name = "burn-autodiff"
-version = "0.21.0"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "3b93a80e43bfab909399444b29ce3894ff51f7e879720bfc75b6007ae6a01c3d"
+version = "0.22.0-pre.1"
+source = "git+https://github.com/tracel-ai/burn?rev=dbf03c516bac61efa3186ba9cafdb92ddf294021#dbf03c516bac61efa3186ba9cafdb92ddf294021"
 dependencies = [
  "burn-backend",
  "burn-std",
@@ -321,15 +352,16 @@ dependencies = [
  "hashbrown 0.16.1",
  "log",
  "num-traits",
+ "parking_lot",
  "portable-atomic",
+ "portable-atomic-util",
  "spin",
 ]
 
 [[package]]
 name = "burn-backend"
-version = "0.21.0"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "64491519ac0867f550fa9c726cd443e5db94608c629050986cf2614c8c5ad39f"
+version = "0.22.0-pre.1"
+source = "git+https://github.com/tracel-ai/burn?rev=dbf03c516bac61efa3186ba9cafdb92ddf294021#dbf03c516bac61efa3186ba9cafdb92ddf294021"
 dependencies = [
  "burn-std",
  "bytemuck",
@@ -363,7 +395,7 @@ dependencies = [
 name = "burn-central-artifact"
 version = "0.6.0"
 dependencies = [
- "reqwest",
+ "reqwest 0.13.3",
  "serde",
  "serde_json",
  "sha2",
@@ -377,7 +409,7 @@ version = "0.7.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "aa5902babcc14874fe8e4f1edfdcc8b686b9dbc3f8e0dfe20519af6a028aad4e"
 dependencies = [
- "reqwest",
+ "reqwest 0.13.3",
  "serde",
  "serde_json",
  "serde_with",
@@ -482,9 +514,8 @@ dependencies = [
 
 [[package]]
 name = "burn-core"
-version = "0.21.0"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "5bde1e3b8e7e39b0aa71cd5905207ceea5c3478bec47bdb64acf72dcd0d6f978"
+version = "0.22.0-pre.1"
+source = "git+https://github.com/tracel-ai/burn?rev=dbf03c516bac61efa3186ba9cafdb92ddf294021#dbf03c516bac61efa3186ba9cafdb92ddf294021"
 dependencies = [
  "ahash",
  "bincode",
@@ -511,10 +542,65 @@ dependencies = [
 ]
 
 [[package]]
+name = "burn-cpu"
+version = "0.22.0-pre.1"
+source = "git+https://github.com/tracel-ai/burn?rev=dbf03c516bac61efa3186ba9cafdb92ddf294021#dbf03c516bac61efa3186ba9cafdb92ddf294021"
+dependencies = [
+ "burn-backend",
+ "burn-cubecl",
+ "cubecl",
+]
+
+[[package]]
+name = "burn-cubecl"
+version = "0.22.0-pre.1"
+source = "git+https://github.com/tracel-ai/burn?rev=dbf03c516bac61efa3186ba9cafdb92ddf294021#dbf03c516bac61efa3186ba9cafdb92ddf294021"
+dependencies = [
+ "burn-backend",
+ "burn-cubecl-fusion",
+ "burn-fusion",
+ "burn-ir",
+ "burn-std",
+ "cubecl",
+ "cubek",
+ "derive-new",
+ "futures-lite",
+ "log",
+ "serde",
+ "text_placeholder",
+]
+
+[[package]]
+name = "burn-cubecl-fusion"
+version = "0.22.0-pre.1"
+source = "git+https://github.com/tracel-ai/burn?rev=dbf03c516bac61efa3186ba9cafdb92ddf294021#dbf03c516bac61efa3186ba9cafdb92ddf294021"
+dependencies = [
+ "burn-backend",
+ "burn-fusion",
+ "burn-ir",
+ "burn-std",
+ "cubecl",
+ "cubek",
+ "derive-new",
+ "hashbrown 0.16.1",
+ "serde",
+ "spin",
+]
+
+[[package]]
+name = "burn-cuda"
+version = "0.22.0-pre.1"
+source = "git+https://github.com/tracel-ai/burn?rev=dbf03c516bac61efa3186ba9cafdb92ddf294021#dbf03c516bac61efa3186ba9cafdb92ddf294021"
+dependencies = [
+ "burn-backend",
+ "burn-cubecl",
+ "cubecl",
+]
+
+[[package]]
 name = "burn-dataset"
-version = "0.21.0"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "ba469fba38357c8bb65458873ddfd82aa97534aec0b3bae93d4c44604fc63839"
+version = "0.22.0-pre.1"
+source = "git+https://github.com/tracel-ai/burn?rev=dbf03c516bac61efa3186ba9cafdb92ddf294021#dbf03c516bac61efa3186ba9cafdb92ddf294021"
 dependencies = [
  "csv",
  "derive-new",
@@ -531,9 +617,8 @@ dependencies = [
 
 [[package]]
 name = "burn-derive"
-version = "0.21.0"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "dce7be43cdfc9903c43dbaf3f4821543e0497d79047d8fc9ee9084e448844446"
+version = "0.22.0-pre.1"
+source = "git+https://github.com/tracel-ai/burn?rev=dbf03c516bac61efa3186ba9cafdb92ddf294021#dbf03c516bac61efa3186ba9cafdb92ddf294021"
 dependencies = [
  "derive-new",
  "proc-macro2",
@@ -543,21 +628,25 @@ dependencies = [
 
 [[package]]
 name = "burn-dispatch"
-version = "0.21.0"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "c2087b9e12323e0d25cc0ebdccfee40427dfdec4a23fa6d3f49ba2aa1f94ac17"
+version = "0.22.0-pre.1"
+source = "git+https://github.com/tracel-ai/burn?rev=dbf03c516bac61efa3186ba9cafdb92ddf294021#dbf03c516bac61efa3186ba9cafdb92ddf294021"
 dependencies = [
  "burn-autodiff",
  "burn-backend",
+ "burn-cpu",
+ "burn-cuda",
+ "burn-flex",
  "burn-ndarray",
+ "burn-rocm",
+ "burn-tch",
+ "burn-wgpu",
  "paste",
 ]
 
 [[package]]
 name = "burn-flex"
-version = "0.21.0"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "0098bf6555c151517b4c98ca0e8ed1ab6a976e40f5f4e967c117b00eee21e192"
+version = "0.22.0-pre.1"
+source = "git+https://github.com/tracel-ai/burn?rev=dbf03c516bac61efa3186ba9cafdb92ddf294021#dbf03c516bac61efa3186ba9cafdb92ddf294021"
 dependencies = [
  "aligned-vec",
  "burn-backend",
@@ -573,10 +662,26 @@ dependencies = [
 ]
 
 [[package]]
+name = "burn-fusion"
+version = "0.22.0-pre.1"
+source = "git+https://github.com/tracel-ai/burn?rev=dbf03c516bac61efa3186ba9cafdb92ddf294021#dbf03c516bac61efa3186ba9cafdb92ddf294021"
+dependencies = [
+ "burn-backend",
+ "burn-ir",
+ "burn-std",
+ "derive-new",
+ "hashbrown 0.16.1",
+ "log",
+ "serde",
+ "smallvec",
+ "spin",
+ "tracing",
+]
+
+[[package]]
 name = "burn-ir"
-version = "0.21.0"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "a81a55c32f35c2265d9e15ba2e796013d9780d5a49f9e21ea0ac4d29609dbf13"
+version = "0.22.0-pre.1"
+source = "git+https://github.com/tracel-ai/burn?rev=dbf03c516bac61efa3186ba9cafdb92ddf294021#dbf03c516bac61efa3186ba9cafdb92ddf294021"
 dependencies = [
  "burn-backend",
  "hashbrown 0.16.1",
@@ -585,18 +690,19 @@ dependencies = [
 
 [[package]]
 name = "burn-ndarray"
-version = "0.21.0"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "dceb9692e292782bab7ad0259e8e8f5ee80ba2b0329a78f0ba589a26a9633dd6"
+version = "0.22.0-pre.1"
+source = "git+https://github.com/tracel-ai/burn?rev=dbf03c516bac61efa3186ba9cafdb92ddf294021#dbf03c516bac61efa3186ba9cafdb92ddf294021"
 dependencies = [
  "atomic_float",
+ "burn-autodiff",
  "burn-backend",
  "burn-ir",
  "burn-std",
  "const-random",
  "libm",
+ "macerator",
  "matrixmultiply",
- "ndarray",
+ "ndarray 0.17.2",
  "num-traits",
  "paste",
  "portable-atomic",
@@ -606,9 +712,8 @@ dependencies = [
 
 [[package]]
 name = "burn-nn"
-version = "0.21.0"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "93e4acd90806fa8663610f1071f3a8992eb98637d2d0816ee3062b334f61af00"
+version = "0.22.0-pre.1"
+source = "git+https://github.com/tracel-ai/burn?rev=dbf03c516bac61efa3186ba9cafdb92ddf294021#dbf03c516bac61efa3186ba9cafdb92ddf294021"
 dependencies = [
  "burn-core",
  "num-traits",
@@ -616,9 +721,8 @@ dependencies = [
 
 [[package]]
 name = "burn-optim"
-version = "0.21.0"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "4c5ea466ae0b85bf18f7656cdc152050dc8c581057fbbe33bbed267e22600228"
+version = "0.22.0-pre.1"
+source = "git+https://github.com/tracel-ai/burn?rev=dbf03c516bac61efa3186ba9cafdb92ddf294021#dbf03c516bac61efa3186ba9cafdb92ddf294021"
 dependencies = [
  "burn-core",
  "derive-new",
@@ -629,13 +733,23 @@ dependencies = [
 ]
 
 [[package]]
+name = "burn-rocm"
+version = "0.22.0-pre.1"
+source = "git+https://github.com/tracel-ai/burn?rev=dbf03c516bac61efa3186ba9cafdb92ddf294021#dbf03c516bac61efa3186ba9cafdb92ddf294021"
+dependencies = [
+ "burn-backend",
+ "burn-cubecl",
+ "cubecl",
+]
+
+[[package]]
 name = "burn-std"
-version = "0.21.0"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "81c7eb60eb2c316854af5b214fd55f59fc7b0e25dfde7db671f09cc49f269048"
+version = "0.22.0-pre.1"
+source = "git+https://github.com/tracel-ai/burn?rev=dbf03c516bac61efa3186ba9cafdb92ddf294021#dbf03c516bac61efa3186ba9cafdb92ddf294021"
 dependencies = [
  "bytemuck",
  "bytes",
+ "cubecl",
  "cubecl-common",
  "cubecl-zspace",
  "half",
@@ -646,29 +760,43 @@ dependencies = [
 ]
 
 [[package]]
-name = "burn-tensor"
-version = "0.21.0"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "223ed3804bb9436e401fc57b87e44c86267070b870813520ed9f706c80c81442"
+name = "burn-tch"
+version = "0.22.0-pre.1"
+source = "git+https://github.com/tracel-ai/burn?rev=dbf03c516bac61efa3186ba9cafdb92ddf294021#dbf03c516bac61efa3186ba9cafdb92ddf294021"
 dependencies = [
  "burn-backend",
+ "cc",
+ "libc",
+ "log",
+ "tch",
+ "torch-sys",
+]
+
+[[package]]
+name = "burn-tensor"
+version = "0.22.0-pre.1"
+source = "git+https://github.com/tracel-ai/burn?rev=dbf03c516bac61efa3186ba9cafdb92ddf294021#dbf03c516bac61efa3186ba9cafdb92ddf294021"
+dependencies = [
+ "burn-backend",
+ "burn-dispatch",
  "burn-std",
  "colored",
  "derive-new",
+ "enumset",
  "num-traits",
  "serde",
 ]
 
 [[package]]
 name = "burn-train"
-version = "0.21.0"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "fa65e2e569e571bb8dc9d37aa8fcf715f522f8159c6ee87f665c1961fee5259f"
+version = "0.22.0-pre.1"
+source = "git+https://github.com/tracel-ai/burn?rev=dbf03c516bac61efa3186ba9cafdb92ddf294021#dbf03c516bac61efa3186ba9cafdb92ddf294021"
 dependencies = [
  "async-channel",
  "burn-core",
  "burn-flex",
  "burn-optim",
+ "burn-std",
  "derive-new",
  "log",
  "rand 0.10.1",
@@ -678,6 +806,16 @@ dependencies = [
  "tracing-appender",
  "tracing-core",
  "tracing-subscriber",
+]
+
+[[package]]
+name = "burn-wgpu"
+version = "0.22.0-pre.1"
+source = "git+https://github.com/tracel-ai/burn?rev=dbf03c516bac61efa3186ba9cafdb92ddf294021#dbf03c516bac61efa3186ba9cafdb92ddf294021"
+dependencies = [
+ "burn-backend",
+ "burn-cubecl",
+ "cubecl",
 ]
 
 [[package]]
@@ -717,6 +855,16 @@ dependencies = [
 
 [[package]]
 name = "bzip2"
+version = "0.4.4"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "bdb116a6ef3f6c3698828873ad02c3014b3c85cadb88496095628e3ef1e347f8"
+dependencies = [
+ "bzip2-sys",
+ "libc",
+]
+
+[[package]]
+name = "bzip2"
 version = "0.6.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "f3a53fac24f34a81bc9954b5d6cfce0c21e18ec6959f44f56e8e90e4bb7c346c"
@@ -725,10 +873,29 @@ dependencies = [
 ]
 
 [[package]]
-name = "cc"
-version = "1.2.57"
+name = "bzip2-sys"
+version = "0.1.13+1.0.8"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "7a0dd1ca384932ff3641c8718a02769f1698e7563dc6974ffd03346116310423"
+checksum = "225bff33b2141874fe80d71e07d6eec4f85c5c216453dd96388240f96e1acc14"
+dependencies = [
+ "cc",
+ "pkg-config",
+]
+
+[[package]]
+name = "caseless"
+version = "0.2.2"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "8b6fd507454086c8edfd769ca6ada439193cdb209c7681712ef6275cccbfe5d8"
+dependencies = [
+ "unicode-normalization",
+]
+
+[[package]]
+name = "cc"
+version = "1.2.62"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "a1dce859f0832a7d088c4f1119888ab94ef4b5d6795d1ce05afb7fe159d79f98"
 dependencies = [
  "find-msvc-tools",
  "jobserver",
@@ -737,10 +904,13 @@ dependencies = [
 ]
 
 [[package]]
-name = "cesu8"
-version = "1.1.0"
+name = "cexpr"
+version = "0.6.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "6d43a04d8753f35258c91f8ec639f792891f748a1edbd759cf1dcea3382ad83c"
+checksum = "6fac387a98bb7c37292057cffc56d62ecb629900026402633ae9160df93a8766"
+dependencies = [
+ "nom 7.1.3",
+]
 
 [[package]]
 name = "cfg-if"
@@ -817,10 +987,21 @@ dependencies = [
 ]
 
 [[package]]
-name = "clap"
-version = "4.6.0"
+name = "clang-sys"
+version = "1.8.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "b193af5b67834b676abd72466a96c1024e6a6ad978a1f484bd90b85c94041351"
+checksum = "0b023947811758c97c59bf9d1c188fd619ad4718dcaa767947df1cadb14f39f4"
+dependencies = [
+ "glob",
+ "libc",
+ "libloading 0.8.9",
+]
+
+[[package]]
+name = "clap"
+version = "4.6.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "1ddb117e43bbf7dacf0a4190fef4d345b9bad68dfc649cb349e7d17d28428e51"
 dependencies = [
  "clap_builder",
  "clap_derive",
@@ -840,9 +1021,9 @@ dependencies = [
 
 [[package]]
 name = "clap_derive"
-version = "4.6.0"
+version = "4.6.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "1110bd8a634a1ab8cb04345d8d878267d57c3cf1b38d91b71af6686408bbca6a"
+checksum = "f2ce8604710f6733aa641a2b3731eaa1e8b3d9973d5e3565da11800813f997a9"
 dependencies = [
  "heck",
  "proc-macro2",
@@ -858,9 +1039,9 @@ checksum = "c8d4a3bb8b1e0c1050499d1815f5ab16d04f0959b233085fb31653fbfc9d98f9"
 
 [[package]]
 name = "cmake"
-version = "0.1.57"
+version = "0.1.58"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "75443c44cd6b379beb8c5b45d85d0773baf31cce901fe7bb252f4eff3008ef7d"
+checksum = "c0f78a02292a74a88ac736019ab962ece0bc380e3f977bf72e376c5d78ff0678"
 dependencies = [
  "cc",
 ]
@@ -902,6 +1083,20 @@ dependencies = [
 ]
 
 [[package]]
+name = "comrak"
+version = "0.39.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "2fefab951771fc3beeed0773ce66a4f7b706273fc6c4c95b08dd1615744abcf5"
+dependencies = [
+ "caseless",
+ "entities",
+ "memchr",
+ "slug",
+ "typed-arena",
+ "unicode_categories",
+]
+
+[[package]]
 name = "concurrent-queue"
 version = "2.5.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -932,9 +1127,30 @@ dependencies = [
 
 [[package]]
 name = "constant_time_eq"
+version = "0.1.5"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "245097e9a4535ee1e3e3931fcfcd55a796a44c643e8596ff6566d68f09b87bbc"
+
+[[package]]
+name = "constant_time_eq"
 version = "0.3.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "7c74b8349d32d297c9134b8c88677813a227df8f779daa29bfc29c183fe3dca6"
+
+[[package]]
+name = "constcat"
+version = "0.6.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "136d3e02915a2cea4d74caa8681e2d44b1c3254bdbf17d11d41d587ff858832c"
+
+[[package]]
+name = "convert_case"
+version = "0.8.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "baaaa0ecca5b51987b9423ccdc971514dd8b0bb7b4060b983d3664dad3f1f89f"
+dependencies = [
+ "unicode-segmentation",
+]
 
 [[package]]
 name = "convert_case"
@@ -965,7 +1181,7 @@ dependencies = [
  "cookie",
  "document-features",
  "idna",
- "indexmap 2.13.0",
+ "indexmap 2.14.0",
  "log",
  "serde",
  "serde_derive",
@@ -1029,9 +1245,9 @@ dependencies = [
 
 [[package]]
 name = "crc-catalog"
-version = "2.4.0"
+version = "2.5.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "19d374276b40fb8bbdee95aef7c7fa6b5316ec764510eb64b8dd0e2ed0d7e7f5"
+checksum = "217698eaf96b4a3f0bc4f3662aaa55bdf913cd54d7204591faa790070c6d0853"
 
 [[package]]
 name = "crc32fast"
@@ -1181,23 +1397,24 @@ dependencies = [
 
 [[package]]
 name = "cubecl"
-version = "0.10.0"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "fd203fef6e359472e4cb8f6c0ef3eca062815a1edd560eb6d6c1d5c1397838d9"
+version = "0.11.0-pre.1"
+source = "git+https://github.com/tracel-ai/cubecl?rev=901d37dbd4a916b764360e4fea111b01356f8263#901d37dbd4a916b764360e4fea111b01356f8263"
 dependencies = [
  "cubecl-core",
+ "cubecl-cpu",
  "cubecl-cuda",
+ "cubecl-hip",
  "cubecl-ir",
  "cubecl-runtime",
+ "cubecl-std",
  "cubecl-wgpu",
  "half",
 ]
 
 [[package]]
 name = "cubecl-common"
-version = "0.10.0"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "cc956c2dcc993f16f748d03bfdbd900f75cab4d469f4e5d8924f8ee128e861ad"
+version = "0.11.0-pre.1"
+source = "git+https://github.com/tracel-ai/cubecl?rev=901d37dbd4a916b764360e4fea111b01356f8263#901d37dbd4a916b764360e4fea111b01356f8263"
 dependencies = [
  "backtrace",
  "bytemuck",
@@ -1227,7 +1444,8 @@ dependencies = [
  "serde_bytes",
  "serde_json",
  "spin",
- "toml 1.1.0+spec-1.1.0",
+ "toml 1.1.2+spec-1.1.0",
+ "tracing",
  "tynm",
  "wasm-bindgen-futures",
  "web-time",
@@ -1236,9 +1454,8 @@ dependencies = [
 
 [[package]]
 name = "cubecl-core"
-version = "0.10.0"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "a7522e7acf25d7848032c7b5270780f9f2abe84e13c7ed6345aa27ba70c312ca"
+version = "0.11.0-pre.1"
+source = "git+https://github.com/tracel-ai/cubecl?rev=901d37dbd4a916b764360e4fea111b01356f8263#901d37dbd4a916b764360e4fea111b01356f8263"
 dependencies = [
  "bitflags",
  "bytemuck",
@@ -1258,14 +1475,14 @@ dependencies = [
  "paste",
  "serde",
  "serde_json",
+ "tracing",
  "variadics_please",
 ]
 
 [[package]]
 name = "cubecl-cpp"
-version = "0.10.0"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "411af04828cbf4583ecd388579fb30cd7a644eec19a334bb8f0d9d08522e1458"
+version = "0.11.0-pre.1"
+source = "git+https://github.com/tracel-ai/cubecl?rev=901d37dbd4a916b764360e4fea111b01356f8263#901d37dbd4a916b764360e4fea111b01356f8263"
 dependencies = [
  "bytemuck",
  "cubecl-common",
@@ -1274,15 +1491,35 @@ dependencies = [
  "cubecl-runtime",
  "derive-new",
  "half",
- "itertools",
+ "itertools 0.14.0",
  "log",
 ]
 
 [[package]]
+name = "cubecl-cpu"
+version = "0.11.0-pre.1"
+source = "git+https://github.com/tracel-ai/cubecl?rev=901d37dbd4a916b764360e4fea111b01356f8263#901d37dbd4a916b764360e4fea111b01356f8263"
+dependencies = [
+ "bytemuck",
+ "cubecl-common",
+ "cubecl-core",
+ "cubecl-opt",
+ "cubecl-runtime",
+ "cubecl-std",
+ "derive-new",
+ "half",
+ "log",
+ "paste",
+ "serde",
+ "sysinfo",
+ "tracel-llvm",
+ "tracel-llvm-bundler",
+]
+
+[[package]]
 name = "cubecl-cuda"
-version = "0.10.0"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "b6b0a69ff45688d322ad8e92c8bf645167b9ca490fa8fa087fc6adac8c5e46be"
+version = "0.11.0-pre.1"
+source = "git+https://github.com/tracel-ai/cubecl?rev=901d37dbd4a916b764360e4fea111b01356f8263#901d37dbd4a916b764360e4fea111b01356f8263"
 dependencies = [
  "bytemuck",
  "cubecl-common",
@@ -1294,13 +1531,42 @@ dependencies = [
  "half",
  "log",
  "serde",
+ "tracing",
+]
+
+[[package]]
+name = "cubecl-hip"
+version = "0.11.0-pre.1"
+source = "git+https://github.com/tracel-ai/cubecl?rev=901d37dbd4a916b764360e4fea111b01356f8263#901d37dbd4a916b764360e4fea111b01356f8263"
+dependencies = [
+ "bytemuck",
+ "cubecl-common",
+ "cubecl-core",
+ "cubecl-cpp",
+ "cubecl-hip-sys",
+ "cubecl-runtime",
+ "derive-new",
+ "half",
+ "log",
+ "paste",
+ "serde",
+ "tracing",
+]
+
+[[package]]
+name = "cubecl-hip-sys"
+version = "7.1.5280200"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "bcdd98f72d6f17836a0477bcd5ae5dd6b57a80fb62a3c0919f867a231f897f28"
+dependencies = [
+ "libc",
+ "regex",
 ]
 
 [[package]]
 name = "cubecl-ir"
-version = "0.10.0"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "d28a897a40c8ee6c57a8b8d76d8823ba2e97f4c2b83db9338f17a0752132d486"
+version = "0.11.0-pre.1"
+source = "git+https://github.com/tracel-ai/cubecl?rev=901d37dbd4a916b764360e4fea111b01356f8263#901d37dbd4a916b764360e4fea111b01356f8263"
 dependencies = [
  "cubecl-common",
  "cubecl-macros-internal",
@@ -1320,9 +1586,8 @@ dependencies = [
 
 [[package]]
 name = "cubecl-macros"
-version = "0.10.0"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "77aa6df563e8e6a0926d2e9eeacb968737940a0e1ae9be819f6a65a341006e12"
+version = "0.11.0-pre.1"
+source = "git+https://github.com/tracel-ai/cubecl?rev=901d37dbd4a916b764360e4fea111b01356f8263#901d37dbd4a916b764360e4fea111b01356f8263"
 dependencies = [
  "cubecl-common",
  "darling 0.23.0",
@@ -1337,9 +1602,8 @@ dependencies = [
 
 [[package]]
 name = "cubecl-macros-internal"
-version = "0.10.0"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "a515651a5a91e25d87f71f311f80a088e6cf815798b9922560a97636da6b8740"
+version = "0.11.0-pre.1"
+source = "git+https://github.com/tracel-ai/cubecl?rev=901d37dbd4a916b764360e4fea111b01356f8263#901d37dbd4a916b764360e4fea111b01356f8263"
 dependencies = [
  "darling 0.23.0",
  "proc-macro2",
@@ -1349,9 +1613,8 @@ dependencies = [
 
 [[package]]
 name = "cubecl-opt"
-version = "0.10.0"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "0a599c6c3efefdcee8636994c90e58ef696c7efbed2d18b5b5ad8d5f29923abb"
+version = "0.11.0-pre.1"
+source = "git+https://github.com/tracel-ai/cubecl?rev=901d37dbd4a916b764360e4fea111b01356f8263#901d37dbd4a916b764360e4fea111b01356f8263"
 dependencies = [
  "cubecl-common",
  "cubecl-core",
@@ -1367,9 +1630,8 @@ dependencies = [
 
 [[package]]
 name = "cubecl-runtime"
-version = "0.10.0"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "b68491bf5b3e997ae36bdc4e63b4ccd6d2f0e86b3b596a5d7a48d2b9e92622a0"
+version = "0.11.0-pre.1"
+source = "git+https://github.com/tracel-ai/cubecl?rev=901d37dbd4a916b764360e4fea111b01356f8263#901d37dbd4a916b764360e4fea111b01356f8263"
 dependencies = [
  "ahash",
  "async-channel",
@@ -1390,16 +1652,32 @@ dependencies = [
  "serde_json",
  "spin",
  "thiserror 2.0.18",
- "toml 1.1.0+spec-1.1.0",
+ "toml 1.1.2+spec-1.1.0",
+ "tracing",
  "wasm-bindgen-futures",
  "web-time",
 ]
 
 [[package]]
+name = "cubecl-std"
+version = "0.11.0-pre.1"
+source = "git+https://github.com/tracel-ai/cubecl?rev=901d37dbd4a916b764360e4fea111b01356f8263#901d37dbd4a916b764360e4fea111b01356f8263"
+dependencies = [
+ "cubecl-common",
+ "cubecl-core",
+ "cubecl-runtime",
+ "half",
+ "num-traits",
+ "paste",
+ "serde",
+ "spin",
+ "variadics_please",
+]
+
+[[package]]
 name = "cubecl-wgpu"
-version = "0.10.0"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "4d3663c6e1a86187172b2cee495b6b533e7d91a2cb37e26f421649e315fe4c3a"
+version = "0.11.0-pre.1"
+source = "git+https://github.com/tracel-ai/cubecl?rev=901d37dbd4a916b764360e4fea111b01356f8263#901d37dbd4a916b764360e4fea111b01356f8263"
 dependencies = [
  "async-channel",
  "bytemuck",
@@ -1415,19 +1693,155 @@ dependencies = [
  "hashbrown 0.16.1",
  "log",
  "sanitize-filename",
+ "tracing",
  "wasm-bindgen-futures",
  "wgpu",
 ]
 
 [[package]]
 name = "cubecl-zspace"
-version = "0.10.0"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "04054d95698afab785a4dda9f949e297831dd9e4cc6d036a93e6603f88e88b07"
+version = "0.11.0-pre.1"
+source = "git+https://github.com/tracel-ai/cubecl?rev=901d37dbd4a916b764360e4fea111b01356f8263#901d37dbd4a916b764360e4fea111b01356f8263"
 dependencies = [
  "derive-new",
  "serde",
  "smallvec",
+]
+
+[[package]]
+name = "cubek"
+version = "0.3.0-pre.1"
+source = "git+https://github.com/tracel-ai/cubek?rev=41b8c27d92c6ed5dd4e5b9fe77a9ed8665025562#41b8c27d92c6ed5dd4e5b9fe77a9ed8665025562"
+dependencies = [
+ "cubecl",
+ "cubek-attention",
+ "cubek-convolution",
+ "cubek-fft",
+ "cubek-interpolate",
+ "cubek-matmul",
+ "cubek-pool",
+ "cubek-quant",
+ "cubek-random",
+ "cubek-reduce",
+ "cubek-std",
+]
+
+[[package]]
+name = "cubek-attention"
+version = "0.3.0-pre.1"
+source = "git+https://github.com/tracel-ai/cubek?rev=41b8c27d92c6ed5dd4e5b9fe77a9ed8665025562#41b8c27d92c6ed5dd4e5b9fe77a9ed8665025562"
+dependencies = [
+ "bytemuck",
+ "cubecl",
+ "cubecl-common",
+ "cubek-matmul",
+ "cubek-std",
+ "half",
+ "serde",
+]
+
+[[package]]
+name = "cubek-convolution"
+version = "0.3.0-pre.1"
+source = "git+https://github.com/tracel-ai/cubek?rev=41b8c27d92c6ed5dd4e5b9fe77a9ed8665025562#41b8c27d92c6ed5dd4e5b9fe77a9ed8665025562"
+dependencies = [
+ "bytemuck",
+ "cubecl",
+ "cubecl-common",
+ "cubek-matmul",
+ "cubek-std",
+ "derive-new",
+ "enumset",
+ "half",
+ "serde",
+]
+
+[[package]]
+name = "cubek-fft"
+version = "0.3.0-pre.1"
+source = "git+https://github.com/tracel-ai/cubek?rev=41b8c27d92c6ed5dd4e5b9fe77a9ed8665025562#41b8c27d92c6ed5dd4e5b9fe77a9ed8665025562"
+dependencies = [
+ "cubecl",
+]
+
+[[package]]
+name = "cubek-interpolate"
+version = "0.3.0-pre.1"
+source = "git+https://github.com/tracel-ai/cubek?rev=41b8c27d92c6ed5dd4e5b9fe77a9ed8665025562#41b8c27d92c6ed5dd4e5b9fe77a9ed8665025562"
+dependencies = [
+ "cubecl",
+ "cubecl-common",
+ "thiserror 2.0.18",
+]
+
+[[package]]
+name = "cubek-matmul"
+version = "0.3.0-pre.1"
+source = "git+https://github.com/tracel-ai/cubek?rev=41b8c27d92c6ed5dd4e5b9fe77a9ed8665025562#41b8c27d92c6ed5dd4e5b9fe77a9ed8665025562"
+dependencies = [
+ "bytemuck",
+ "cubecl",
+ "cubecl-common",
+ "cubek-std",
+ "half",
+ "serde",
+]
+
+[[package]]
+name = "cubek-pool"
+version = "0.3.0-pre.1"
+source = "git+https://github.com/tracel-ai/cubek?rev=41b8c27d92c6ed5dd4e5b9fe77a9ed8665025562#41b8c27d92c6ed5dd4e5b9fe77a9ed8665025562"
+dependencies = [
+ "cubecl",
+ "cubecl-common",
+ "thiserror 2.0.18",
+]
+
+[[package]]
+name = "cubek-quant"
+version = "0.3.0-pre.1"
+source = "git+https://github.com/tracel-ai/cubek?rev=41b8c27d92c6ed5dd4e5b9fe77a9ed8665025562#41b8c27d92c6ed5dd4e5b9fe77a9ed8665025562"
+dependencies = [
+ "cubecl",
+ "cubecl-common",
+ "half",
+ "serde",
+]
+
+[[package]]
+name = "cubek-random"
+version = "0.3.0-pre.1"
+source = "git+https://github.com/tracel-ai/cubek?rev=41b8c27d92c6ed5dd4e5b9fe77a9ed8665025562#41b8c27d92c6ed5dd4e5b9fe77a9ed8665025562"
+dependencies = [
+ "cubecl",
+ "cubecl-common",
+ "half",
+ "num-traits",
+ "rand 0.10.1",
+ "serde",
+]
+
+[[package]]
+name = "cubek-reduce"
+version = "0.3.0-pre.1"
+source = "git+https://github.com/tracel-ai/cubek?rev=41b8c27d92c6ed5dd4e5b9fe77a9ed8665025562#41b8c27d92c6ed5dd4e5b9fe77a9ed8665025562"
+dependencies = [
+ "cubecl",
+ "cubek-std",
+ "half",
+ "num-traits",
+ "serde",
+ "thiserror 2.0.18",
+]
+
+[[package]]
+name = "cubek-std"
+version = "0.3.0-pre.1"
+source = "git+https://github.com/tracel-ai/cubek?rev=41b8c27d92c6ed5dd4e5b9fe77a9ed8665025562#41b8c27d92c6ed5dd4e5b9fe77a9ed8665025562"
+dependencies = [
+ "cubecl",
+ "cubecl-common",
+ "half",
 ]
 
 [[package]]
@@ -1601,13 +2015,19 @@ version = "2.1.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "799a97264921d8623a957f6c3b9011f3b5492f557bbb7a5a19b7fa6d06ba8dcb"
 dependencies = [
- "convert_case",
+ "convert_case 0.10.0",
  "proc-macro2",
  "quote",
  "rustc_version",
  "syn",
  "unicode-xid",
 ]
+
+[[package]]
+name = "deunicode"
+version = "1.6.2"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "abd57806937c9cc163efc8ea3910e00a62e2aeb0b8119f1793a978088f8f6b04"
 
 [[package]]
 name = "digest"
@@ -1803,6 +2223,12 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "c34f04666d835ff5d62e058c3995147c06f42fe86ff053337632bca83e42702d"
 
 [[package]]
+name = "entities"
+version = "1.0.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "b5320ae4c3782150d900b79807611a59a99fc9a1d61d686faafc24b93fc8d7ca"
+
+[[package]]
 name = "enum-as-inner"
 version = "0.6.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -1918,9 +2344,19 @@ dependencies = [
 
 [[package]]
 name = "fastrand"
-version = "2.3.0"
+version = "2.4.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "37909eebbb50d72f9059c3b6d82c0463f2ff062c9e95845c43a6c9c0355411be"
+checksum = "9f1f227452a390804cdb637b74a86990f2a7d7ba4b7d5693aac9b4dd6defd8d6"
+
+[[package]]
+name = "filetime"
+version = "0.2.29"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "5c287a33c7f0a620c38e641e7f60827713987b3c0f26e8ddc9462cc69cf75759"
+dependencies = [
+ "cfg-if",
+ "libc",
+]
 
 [[package]]
 name = "find-msvc-tools"
@@ -2328,7 +2764,7 @@ dependencies = [
  "log",
  "presser",
  "thiserror 2.0.18",
- "windows 0.58.0",
+ "windows",
 ]
 
 [[package]]
@@ -2353,9 +2789,9 @@ dependencies = [
 
 [[package]]
 name = "h2"
-version = "0.4.13"
+version = "0.4.14"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "2f44da3a8150a6703ed5d34e164b875fd14c2cdab9af1252a9a1020bde2bdc54"
+checksum = "171fefbc92fe4a4de27e0698d6a5b392d6a0e333506bc49133760b3bcf948733"
 dependencies = [
  "atomic-waker",
  "bytes",
@@ -2363,7 +2799,7 @@ dependencies = [
  "futures-core",
  "futures-sink",
  "http",
- "indexmap 2.13.0",
+ "indexmap 2.14.0",
  "slab",
  "tokio",
  "tokio-util",
@@ -2392,6 +2828,15 @@ checksum = "8a9ee70c43aaf417c914396645a0fa852624801b24ebb7ae78fe8272889ac888"
 
 [[package]]
 name = "hashbrown"
+version = "0.13.2"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "43a3c133739dddd0d2990f9a4bdf8eb4b21ef50e4851ca85ab661199821d510e"
+dependencies = [
+ "ahash",
+]
+
+[[package]]
+name = "hashbrown"
 version = "0.15.5"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "9229cfe53dfd69f0609a49f65461bd93001ea1ef889cd5529dd176593f5338a1"
@@ -2413,10 +2858,22 @@ dependencies = [
 ]
 
 [[package]]
+name = "hashbrown"
+version = "0.17.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "ed5909b6e89a2db4456e54cd5f673791d7eca6732202bbf2a9cc504fe2f9b84a"
+
+[[package]]
 name = "heck"
 version = "0.5.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "2304e00983f87ffb38b55b444b5e3b60a884b5d30c0fca7d82fe33449bbe55ea"
+
+[[package]]
+name = "hermit-abi"
+version = "0.5.2"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "fc0fef456e4baa96da950455cd02c081ca953b141298e41db3fc7e36b1da849c"
 
 [[package]]
 name = "hex"
@@ -2495,9 +2952,9 @@ checksum = "135b12329e5e3ce057a9f972339ea52bc954fe1e9358ef27f95e89716fbc5424"
 
 [[package]]
 name = "hyper"
-version = "1.8.1"
+version = "1.9.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "2ab2d4f250c3d7b1c9fcdff1cece94ea4e2dfbec68614f7b87cb205f24ca9d11"
+checksum = "6299f016b246a94207e63da54dbe807655bf9e00044f73ded42c3ac5305fbcca"
 dependencies = [
  "atomic-waker",
  "bytes",
@@ -2509,7 +2966,6 @@ dependencies = [
  "httparse",
  "itoa",
  "pin-project-lite",
- "pin-utils",
  "smallvec",
  "tokio",
  "want",
@@ -2517,18 +2973,18 @@ dependencies = [
 
 [[package]]
 name = "hyper-rustls"
-version = "0.27.7"
+version = "0.27.9"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "e3c93eb611681b207e1fe55d5a71ecf91572ec8a6705cdb6857f7d8d5242cf58"
+checksum = "33ca68d021ef39cf6463ab54c1d0f5daf03377b70561305bb89a8f83aab66e0f"
 dependencies = [
  "http",
  "hyper",
  "hyper-util",
  "rustls",
- "rustls-pki-types",
  "tokio",
  "tokio-rustls",
  "tower-service",
+ "webpki-roots 1.0.7",
 ]
 
 [[package]]
@@ -2568,7 +3024,7 @@ dependencies = [
  "js-sys",
  "log",
  "wasm-bindgen",
- "windows-core 0.62.2",
+ "windows-core",
 ]
 
 [[package]]
@@ -2582,12 +3038,13 @@ dependencies = [
 
 [[package]]
 name = "icu_collections"
-version = "2.1.1"
+version = "2.2.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "4c6b649701667bbe825c3b7e6388cb521c23d88644678e83c0c4d0a621a34b43"
+checksum = "2984d1cd16c883d7935b9e07e44071dca8d917fd52ecc02c04d5fa0b5a3f191c"
 dependencies = [
  "displaydoc",
  "potential_utf",
+ "utf8_iter",
  "yoke",
  "zerofrom",
  "zerovec",
@@ -2595,9 +3052,9 @@ dependencies = [
 
 [[package]]
 name = "icu_locale_core"
-version = "2.1.1"
+version = "2.2.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "edba7861004dd3714265b4db54a3c390e880ab658fec5f7db895fae2046b5bb6"
+checksum = "92219b62b3e2b4d88ac5119f8904c10f8f61bf7e95b640d25ba3075e6cac2c29"
 dependencies = [
  "displaydoc",
  "litemap",
@@ -2608,9 +3065,9 @@ dependencies = [
 
 [[package]]
 name = "icu_normalizer"
-version = "2.1.1"
+version = "2.2.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "5f6c8828b67bf8908d82127b2054ea1b4427ff0230ee9141c54251934ab1b599"
+checksum = "c56e5ee99d6e3d33bd91c5d85458b6005a22140021cc324cea84dd0e72cff3b4"
 dependencies = [
  "icu_collections",
  "icu_normalizer_data",
@@ -2622,15 +3079,15 @@ dependencies = [
 
 [[package]]
 name = "icu_normalizer_data"
-version = "2.1.1"
+version = "2.2.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "7aedcccd01fc5fe81e6b489c15b247b8b0690feb23304303a9e560f37efc560a"
+checksum = "da3be0ae77ea334f4da67c12f149704f19f81d1adf7c51cf482943e84a2bad38"
 
 [[package]]
 name = "icu_properties"
-version = "2.1.2"
+version = "2.2.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "020bfc02fe870ec3a66d93e677ccca0562506e5872c650f893269e08615d74ec"
+checksum = "bee3b67d0ea5c2cca5003417989af8996f8604e34fb9ddf96208a033901e70de"
 dependencies = [
  "icu_collections",
  "icu_locale_core",
@@ -2642,15 +3099,15 @@ dependencies = [
 
 [[package]]
 name = "icu_properties_data"
-version = "2.1.2"
+version = "2.2.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "616c294cf8d725c6afcd8f55abc17c56464ef6211f9ed59cccffe534129c77af"
+checksum = "8e2bbb201e0c04f7b4b3e14382af113e17ba4f63e2c9d2ee626b720cbce54a14"
 
 [[package]]
 name = "icu_provider"
-version = "2.1.1"
+version = "2.2.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "85962cf0ce02e1e0a629cc34e7ca3e373ce20dda4c4d7294bbd0bf1fdb59e614"
+checksum = "139c4cf31c8b5f33d7e199446eff9c1e02decfc2f0eec2c8d71f65befa45b421"
 dependencies = [
  "displaydoc",
  "icu_locale_core",
@@ -2686,9 +3143,9 @@ dependencies = [
 
 [[package]]
 name = "idna_adapter"
-version = "1.2.1"
+version = "1.2.2"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "3acae9609540aa318d1bc588455225fb2085b9ed0c4f6bd0d9d5bcd86f1a0344"
+checksum = "cb68373c0d6620ef8105e855e7745e18b0d00d3bdb07fb532e434244cdb9a714"
 dependencies = [
  "icu_normalizer",
  "icu_properties",
@@ -2707,12 +3164,12 @@ dependencies = [
 
 [[package]]
 name = "indexmap"
-version = "2.13.0"
+version = "2.14.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "7714e70437a7dc3ac8eb7e6f8df75fd8eb422675fc7678aff7364301092b1017"
+checksum = "d466e9454f08e4a911e14806c24e16fba1b4c121d1ea474396f396069cf949d9"
 dependencies = [
  "equivalent",
- "hashbrown 0.16.1",
+ "hashbrown 0.17.1",
  "serde",
  "serde_core",
 ]
@@ -2753,20 +3210,19 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "d98f6fed1fde3f8c21bc40a1abb88dd75e67924f9cffc3ef95607bad8017f8e2"
 
 [[package]]
-name = "iri-string"
-version = "0.7.11"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "d8e7418f59cc01c88316161279a7f665217ae316b388e58a0d10e29f54f1e5eb"
-dependencies = [
- "memchr",
- "serde",
-]
-
-[[package]]
 name = "is_terminal_polyfill"
 version = "1.70.2"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "a6cb138bb79a146c1bd460005623e142ef0181e3d0219cb493e02f7d08a35695"
+
+[[package]]
+name = "itertools"
+version = "0.13.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "413ee7dfc52ee1a4949ceeb7dbc8a33f2d6c088194d9f922fb8318faf1f01186"
+dependencies = [
+ "either",
+]
 
 [[package]]
 name = "itertools"
@@ -2785,9 +3241,9 @@ checksum = "8f42a60cbdf9a97f5d2305f08a87dc4e09308d1276d28c869c684d7777685682"
 
 [[package]]
 name = "jiff"
-version = "0.2.23"
+version = "0.2.24"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "1a3546dc96b6d42c5f24902af9e2538e82e39ad350b0c766eb3fbf2d8f3d8359"
+checksum = "f00b5dbd620d61dfdcb6007c9c1f6054ebd75319f163d886a9055cec1155073d"
 dependencies = [
  "jiff-static",
  "log",
@@ -2798,9 +3254,9 @@ dependencies = [
 
 [[package]]
 name = "jiff-static"
-version = "0.2.23"
+version = "0.2.24"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "2a8c8b344124222efd714b73bb41f8b5120b27a7cc1c75593a6ff768d9d05aa4"
+checksum = "e000de030ff8022ea1da3f466fbb0f3a809f5e51ed31f6dd931c35181ad8e6d7"
 dependencies = [
  "proc-macro2",
  "quote",
@@ -2809,18 +3265,32 @@ dependencies = [
 
 [[package]]
 name = "jni"
-version = "0.21.1"
+version = "0.22.4"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "1a87aa2bb7d2af34197c04845522473242e1aa17c12f4935d5856491a7fb8c97"
+checksum = "5efd9a482cf3a427f00d6b35f14332adc7902ce91efb778580e180ff90fa3498"
 dependencies = [
- "cesu8",
  "cfg-if",
  "combine",
- "jni-sys 0.3.1",
+ "jni-macros",
+ "jni-sys 0.4.1",
  "log",
- "thiserror 1.0.69",
+ "simd_cesu8",
+ "thiserror 2.0.18",
  "walkdir",
- "windows-sys 0.45.0",
+ "windows-link",
+]
+
+[[package]]
+name = "jni-macros"
+version = "0.22.4"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "a00109accc170f0bdb141fed3e393c565b6f5e072365c3bd58f5b062591560a3"
+dependencies = [
+ "proc-macro2",
+ "quote",
+ "rustc_version",
+ "simd_cesu8",
+ "syn",
 ]
 
 [[package]]
@@ -2863,24 +3333,26 @@ dependencies = [
 
 [[package]]
 name = "js-sys"
-version = "0.3.91"
+version = "0.3.98"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "b49715b7073f385ba4bc528e5747d02e66cb39c6146efb66b781f131f0fb399c"
+checksum = "67df7112613f8bfd9150013a0314e196f4800d3201ae742489d999db2f979f08"
 dependencies = [
+ "cfg-if",
+ "futures-util",
  "once_cell",
  "wasm-bindgen",
 ]
 
 [[package]]
 name = "json-patch"
-version = "4.1.0"
+version = "4.2.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "f300e415e2134745ef75f04562dd0145405c2f7fd92065db029ac4b16b57fe90"
+checksum = "7421438de105a0827e44fadd05377727847d717c80ce29a229f85fd04c427b72"
 dependencies = [
  "jsonptr",
  "serde",
  "serde_json",
- "thiserror 1.0.69",
+ "thiserror 2.0.18",
 ]
 
 [[package]]
@@ -2924,15 +3396,15 @@ checksum = "09edd9e8b54e49e587e4f6295a7d29c3ea94d469cb40ab8ca70b288248a81db2"
 
 [[package]]
 name = "libbz2-rs-sys"
-version = "0.2.2"
+version = "0.2.4"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "2c4a545a15244c7d945065b5d392b2d2d7f21526fba56ce51467b06ed445e8f7"
+checksum = "f8fc329e1457d97a9d58a4e2ca49e3be572431a7e096008efc2e3a3c19d428f4"
 
 [[package]]
 name = "libc"
-version = "0.2.183"
+version = "0.2.186"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "b5b646652bf6661599e1da8901b3b9522896f01e736bad5f723fe7a3a27f899d"
+checksum = "68ab91017fe16c622486840e4c83c9a37afeff978bd239b5293d61ece587de66"
 
 [[package]]
 name = "libloading"
@@ -2955,6 +3427,27 @@ dependencies = [
 ]
 
 [[package]]
+name = "liblzma"
+version = "0.4.6"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "b6033b77c21d1f56deeae8014eb9fbe7bdf1765185a6c508b5ca82eeaed7f899"
+dependencies = [
+ "liblzma-sys",
+ "num_cpus",
+]
+
+[[package]]
+name = "liblzma-sys"
+version = "0.4.6"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "1a60851d15cd8c5346eca4ab8babff585be2ae4bc8097c067291d3ffe2add3b6"
+dependencies = [
+ "cc",
+ "libc",
+ "pkg-config",
+]
+
+[[package]]
 name = "libm"
 version = "0.2.16"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -2962,9 +3455,9 @@ checksum = "b6d2cec3eae94f9f509c767b45932f1ada8350c4bdb85af2fcab4a3c14807981"
 
 [[package]]
 name = "libredox"
-version = "0.1.15"
+version = "0.1.16"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "7ddbf48fd451246b1f8c2610bd3b4ac0cc6e149d89832867093ab69a17194f08"
+checksum = "e02f3bb43d335493c96bf3fd3a321600bf6bd07ed34bc64118e9293bdffea46c"
 dependencies = [
  "libc",
 ]
@@ -2977,9 +3470,9 @@ checksum = "32a66949e030da00e8c7d4434b251670a91556f4144941d37452769c25d58a53"
 
 [[package]]
 name = "litemap"
-version = "0.8.1"
+version = "0.8.2"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "6373607a59f0be73a39b6fe456b8192fcc3585f602af20751600e974dd455e77"
+checksum = "92daf443525c4cce67b150400bc2316076100ce0b3686209eb8cf3c31612e6f0"
 
 [[package]]
 name = "litrs"
@@ -3085,12 +3578,12 @@ checksum = "f8ca58f447f06ed17d5fc4043ce1b10dd205e060fb3ce5b979b8ed8e59ff3f79"
 
 [[package]]
 name = "metrics"
-version = "0.24.3"
+version = "0.24.5"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "5d5312e9ba3771cfa961b585728215e3d972c950a3eed9252aa093d6301277e8"
+checksum = "ff56c2e7dce6bd462e3b8919986a617027481b1dcc703175b58cf9dd98a2f071"
 dependencies = [
- "ahash",
  "portable-atomic",
+ "rapidhash",
 ]
 
 [[package]]
@@ -3099,7 +3592,7 @@ version = "0.18.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "93551ba7648013c25bece467fa087a54dd8dd50a4515182ecf9efb7630b1ed0d"
 dependencies = [
- "indexmap 2.13.0",
+ "indexmap 2.14.0",
  "itoa",
  "lockfree-object-pool",
  "metrics",
@@ -3112,21 +3605,22 @@ dependencies = [
 
 [[package]]
 name = "metrics-util"
-version = "0.20.1"
+version = "0.20.3"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "cdfb1365fea27e6dd9dc1dbc19f570198bc86914533ad639dae939635f096be4"
+checksum = "9e56997f084e57b045edf17c3ed8ba7f9f779c670df8206dfd1c736f4c02dc4a"
 dependencies = [
  "aho-corasick",
  "crossbeam-epoch",
  "crossbeam-utils",
  "hashbrown 0.16.1",
- "indexmap 2.13.0",
+ "indexmap 2.14.0",
  "metrics",
  "ordered-float",
  "quanta",
  "radix_trie",
- "rand 0.9.2",
+ "rand 0.9.4",
  "rand_xoshiro",
+ "rapidhash",
  "sketches-ddsketch",
 ]
 
@@ -3135,6 +3629,12 @@ name = "mime"
 version = "0.3.17"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "6877bb514081ee2a7ff5ef9de3281f14a4dd4bceac4c09388074a6b5df8a139a"
+
+[[package]]
+name = "minimal-lexical"
+version = "0.2.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "68354c5c6bd36d73ff3feceb05efa59b6acb7626617f4962be322a825e61f79a"
 
 [[package]]
 name = "miniz_oxide"
@@ -3148,9 +3648,9 @@ dependencies = [
 
 [[package]]
 name = "mio"
-version = "1.1.1"
+version = "1.2.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "a69bcab0ad47271a0234d9422b131806bf3968021e5dc9328caf2d4cd58557fc"
+checksum = "50b7e5b27aa02a74bac8c3f23f448f8d87ff11f92d3aac1a6ed369ee08cc56c1"
 dependencies = [
  "libc",
  "log",
@@ -3179,7 +3679,7 @@ dependencies = [
  "half",
  "hashbrown 0.16.1",
  "hexf-parse",
- "indexmap 2.13.0",
+ "indexmap 2.14.0",
  "libm",
  "log",
  "num-traits",
@@ -3224,6 +3724,21 @@ checksum = "8d5439c4ad607c3c23abf66de8c8bf57ba8adcd1f129e699851a6e43935d339d"
 
 [[package]]
 name = "ndarray"
+version = "0.16.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "882ed72dce9365842bf196bdeedf5055305f11fc8c03dee7bb0194a6cad34841"
+dependencies = [
+ "matrixmultiply",
+ "num-complex",
+ "num-integer",
+ "num-traits",
+ "portable-atomic",
+ "portable-atomic-util",
+ "rawpointer",
+]
+
+[[package]]
+name = "ndarray"
 version = "0.17.2"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "520080814a7a6b4a6e9070823bb24b4531daac8c4627e08ba5de8c5ef2f2752d"
@@ -3257,9 +3772,9 @@ dependencies = [
 
 [[package]]
 name = "nix"
-version = "0.31.2"
+version = "0.31.3"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "5d6d0705320c1e6ba1d912b5e37cf18071b6c2e9b7fa8215a1e8a7651966f5d3"
+checksum = "cf20d2fde8ff38632c426f1165ed7436270b44f199fc55284c38276f9db47c3d"
 dependencies = [
  "bitflags",
  "cfg-if",
@@ -3269,11 +3784,30 @@ dependencies = [
 
 [[package]]
 name = "nom"
+version = "7.1.3"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "d273983c5a657a70a3e8f2a01329822f3b8c8172b73826411a55751e404a0a4a"
+dependencies = [
+ "memchr",
+ "minimal-lexical",
+]
+
+[[package]]
+name = "nom"
 version = "8.0.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "df9761775871bdef83bee530e60050f7e54b1105350d6884eb0fb4f46c2f9405"
 dependencies = [
  "memchr",
+]
+
+[[package]]
+name = "ntapi"
+version = "0.4.3"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "c3b335231dfd352ffb0f8017f3b6027a4917f7df785ea2143d8af2adc66980ae"
+dependencies = [
+ "winapi",
 ]
 
 [[package]]
@@ -3321,9 +3855,9 @@ dependencies = [
 
 [[package]]
 name = "num-conv"
-version = "0.2.0"
+version = "0.2.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "cf97ec579c3c42f953ef76dbf8d55ac91fb219dde70e49aa4a6b7d74e9919050"
+checksum = "c6673768db2d862beb9b39a78fdcb1a69439615d5794a1be50caa9bc92c81967"
 
 [[package]]
 name = "num-integer"
@@ -3367,6 +3901,16 @@ dependencies = [
 ]
 
 [[package]]
+name = "num_cpus"
+version = "1.17.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "91df4bbde75afed763b708b7eee1e8e7651e02d97f6d5dd763e89367e957b23b"
+dependencies = [
+ "hermit-abi",
+ "libc",
+]
+
+[[package]]
 name = "objc2"
 version = "0.6.4"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -3400,6 +3944,16 @@ checksum = "e3e0adef53c21f888deb4fa59fc59f7eb17404926ee8a6f59f5df0fd7f9f3272"
 dependencies = [
  "bitflags",
  "objc2",
+ "objc2-core-foundation",
+]
+
+[[package]]
+name = "objc2-io-kit"
+version = "0.3.2"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "33fafba39597d6dc1fb709123dfa8289d39406734be322956a69f0931c73bb15"
+dependencies = [
+ "libc",
  "objc2-core-foundation",
 ]
 
@@ -3457,15 +4011,14 @@ checksum = "cfe21416a02c693fb9f980befcb230ecc70b0b3d1cc4abf88b9675c4c1457f0c"
 
 [[package]]
 name = "openssl"
-version = "0.10.76"
+version = "0.10.79"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "951c002c75e16ea2c65b8c7e4d3d51d5530d8dfa7d060b4776828c88cfb18ecf"
+checksum = "bf0b434746ee2832f4f0baf10137e1cabb18cbe6912c69e2e33263c45250f542"
 dependencies = [
  "bitflags",
  "cfg-if",
  "foreign-types",
  "libc",
- "once_cell",
  "openssl-macros",
  "openssl-sys",
 ]
@@ -3489,9 +4042,9 @@ checksum = "7c87def4c32ab89d880effc9e097653c8da5d6ef28e6b539d313baaacfbafcbe"
 
 [[package]]
 name = "openssl-sys"
-version = "0.9.112"
+version = "0.9.115"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "57d55af3b3e226502be1526dfdba67ab0e9c96fc293004e79576b2b9edb0dbdb"
+checksum = "158fe5b292746440aa6e7a7e690e55aeb72d41505e2804c23c6973ad0e9c9781"
 dependencies = [
  "cc",
  "libc",
@@ -3507,9 +4060,9 @@ checksum = "04744f49eae99ab78e0d5c0b603ab218f515ea8cfe5a456d7629ad883a3b6e7d"
 
 [[package]]
 name = "ordered-float"
-version = "5.1.0"
+version = "5.3.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "7f4779c6901a562440c3786d08192c6fbda7c1c2060edd10006b05ee35d10f2d"
+checksum = "b7d950ca161dc355eaf28f82b11345ed76c6e1f6eb1f4f4479e0323b9e2fbd0e"
 dependencies = [
  "num-traits",
 ]
@@ -3550,10 +4103,33 @@ dependencies = [
 ]
 
 [[package]]
+name = "password-hash"
+version = "0.4.2"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "7676374caaee8a325c9e7a2ae557f216c5563a171d6997b0ef8a65af35147700"
+dependencies = [
+ "base64ct",
+ "rand_core 0.6.4",
+ "subtle",
+]
+
+[[package]]
 name = "paste"
 version = "1.0.15"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "57c0d7b74b563b49d38dae00a0c37d4d6de9b432382b2892f0574ddcae73fd0a"
+
+[[package]]
+name = "pbkdf2"
+version = "0.11.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "83a0692ec44e4cf1ef28ca317f14f8f07da2d95ec3fa01f86e4467b725e60917"
+dependencies = [
+ "digest",
+ "hmac",
+ "password-hash",
+ "sha2",
+]
 
 [[package]]
 name = "pbkdf2"
@@ -3579,7 +4155,7 @@ checksum = "8701b58ea97060d5e5b155d383a69952a60943f0e6dfe30b04c287beb0b27455"
 dependencies = [
  "fixedbitset",
  "hashbrown 0.15.5",
- "indexmap 2.13.0",
+ "indexmap 2.14.0",
  "serde",
 ]
 
@@ -3590,16 +4166,10 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "a89322df9ebe1c1578d689c92318e070967d1042b512afbe49518723f4e6d5cd"
 
 [[package]]
-name = "pin-utils"
-version = "0.1.0"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "8b870d8c151b6f2fb93e84a13146138f05d02ed11c7e7c54f8826aaaf7c9f184"
-
-[[package]]
 name = "pkg-config"
-version = "0.3.32"
+version = "0.3.33"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "7edddbd0b52d732b21ad9a5fab5c704c14cd949e5e9a1ec5929a24fded1b904c"
+checksum = "19f132c84eca552bf34cab8ec81f1c1dcc229b811638f9d283dceabe58c5569e"
 
 [[package]]
 name = "portable-atomic"
@@ -3612,18 +4182,18 @@ dependencies = [
 
 [[package]]
 name = "portable-atomic-util"
-version = "0.2.6"
+version = "0.2.7"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "091397be61a01d4be58e7841595bd4bfedb15f1cd54977d79b8271e94ed799a3"
+checksum = "c2a106d1259c23fac8e543272398ae0e3c0b8d33c88ed73d0cc71b0f1d902618"
 dependencies = [
  "portable-atomic",
 ]
 
 [[package]]
 name = "potential_utf"
-version = "0.1.4"
+version = "0.1.5"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "b73949432f5e2a09657003c25bca5e19a0e9c84f8058ca374f49e0ebe605af77"
+checksum = "0103b1cef7ec0cf76490e969665504990193874ea05c85ff9bab8b911d0a0564"
 dependencies = [
  "zerovec",
 ]
@@ -3685,9 +4255,9 @@ dependencies = [
 
 [[package]]
 name = "profiling"
-version = "1.0.17"
+version = "1.0.18"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "3eb8486b569e12e2c32ad3e204dbaba5e4b5b216e9367044f25f1dba42341773"
+checksum = "3d595e54a326bc53c1c197b32d295e14b169e3cfeaa8dc82b529f947fba6bcf5"
 
 [[package]]
 name = "pulp"
@@ -3738,7 +4308,7 @@ dependencies = [
  "pin-project-lite",
  "quinn-proto",
  "quinn-udp",
- "rustc-hash 2.1.1",
+ "rustc-hash 2.1.2",
  "rustls",
  "socket2",
  "thiserror 2.0.18",
@@ -3757,9 +4327,9 @@ dependencies = [
  "bytes",
  "getrandom 0.3.4",
  "lru-slab",
- "rand 0.9.2",
+ "rand 0.9.4",
  "ring",
- "rustc-hash 2.1.1",
+ "rustc-hash 2.1.2",
  "rustls",
  "rustls-pki-types",
  "slab",
@@ -3816,11 +4386,22 @@ dependencies = [
 
 [[package]]
 name = "rand"
-version = "0.9.2"
+version = "0.8.6"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "6db2770f06117d490610c7488547d543617b21bfa07796d7a12f6f1bd53850d1"
+checksum = "5ca0ecfa931c29007047d1bc58e623ab12e5590e8c7cc53200d5202b69266d8a"
 dependencies = [
- "rand_chacha",
+ "libc",
+ "rand_chacha 0.3.1",
+ "rand_core 0.6.4",
+]
+
+[[package]]
+name = "rand"
+version = "0.9.4"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "44c5af06bb1b7d3216d91932aed5265164bf384dc89cd6ba05cf59a35f5f76ea"
+dependencies = [
+ "rand_chacha 0.9.0",
  "rand_core 0.9.5",
 ]
 
@@ -3837,12 +4418,31 @@ dependencies = [
 
 [[package]]
 name = "rand_chacha"
+version = "0.3.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "e6c10a63a0fa32252be49d21e7709d4d4baf8d231c2dbce1eaa8141b9b127d88"
+dependencies = [
+ "ppv-lite86",
+ "rand_core 0.6.4",
+]
+
+[[package]]
+name = "rand_chacha"
 version = "0.9.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "d3022b5f1df60f26e1ffddd6c66e8aa15de382ae63b3a0c1bfc0e4d3e3f325cb"
 dependencies = [
  "ppv-lite86",
  "rand_core 0.9.5",
+]
+
+[[package]]
+name = "rand_core"
+version = "0.6.4"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "ec0be4795e2f6a28069bec0b5ff3e2ac9bafc99e6a9a7dc3547996c5c816922c"
+dependencies = [
+ "getrandom 0.2.17",
 ]
 
 [[package]]
@@ -3886,6 +4486,15 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "ca45419789ae5a7899559e9512e58ca889e41f04f1f2445e9f4b290ceccd1d08"
 
 [[package]]
+name = "rapidhash"
+version = "4.4.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "b5e48930979c155e2f33aa36ab3119b5ee81332beb6482199a8ecd6029b80b59"
+dependencies = [
+ "rustversion",
+]
+
+[[package]]
 name = "raw-cpuid"
 version = "11.6.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -3920,9 +4529,9 @@ checksum = "60a357793950651c4ed0f3f52338f53b2f809f32d83a07f72909fa13e4c6c1e3"
 
 [[package]]
 name = "rayon"
-version = "1.11.0"
+version = "1.12.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "368f01d005bf8fd9b1206fb6fa653e6c4a81ceb1466406b81792d87c5677a58f"
+checksum = "fb39b166781f92d482534ef4b4b1b2568f42613b53e5b6c160e24cfbfa30926d"
 dependencies = [
  "either",
  "rayon-core",
@@ -4027,9 +4636,50 @@ checksum = "19b30a45b0cd0bcca8037f3d0dc3421eaf95327a17cad11964fb8179b4fc4832"
 
 [[package]]
 name = "reqwest"
-version = "0.13.2"
+version = "0.12.28"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "ab3f43e3283ab1488b624b44b0e988d0acea0b3214e694730a055cb6b2efa801"
+checksum = "eddd3ca559203180a307f12d114c268abf583f59b03cb906fd0b3ff8646c1147"
+dependencies = [
+ "base64",
+ "bytes",
+ "futures-channel",
+ "futures-core",
+ "futures-util",
+ "h2",
+ "http",
+ "http-body",
+ "http-body-util",
+ "hyper",
+ "hyper-rustls",
+ "hyper-util",
+ "js-sys",
+ "log",
+ "percent-encoding",
+ "pin-project-lite",
+ "quinn",
+ "rustls",
+ "rustls-pki-types",
+ "serde",
+ "serde_json",
+ "serde_urlencoded",
+ "sync_wrapper",
+ "tokio",
+ "tokio-rustls",
+ "tower",
+ "tower-http",
+ "tower-service",
+ "url",
+ "wasm-bindgen",
+ "wasm-bindgen-futures",
+ "web-sys",
+ "webpki-roots 1.0.7",
+]
+
+[[package]]
+name = "reqwest"
+version = "0.13.3"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "62e0021ea2c22aed41653bc7e1419abb2c97e038ff2c33d0e1309e49a97deec0"
 dependencies = [
  "base64",
  "bytes",
@@ -4143,9 +4793,9 @@ checksum = "08d43f7aa6b08d49f382cde6a7982047c3426db949b1424bc4b7ec9ae12c6ce2"
 
 [[package]]
 name = "rustc-hash"
-version = "2.1.1"
+version = "2.1.2"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "357703d41365b4b27c590e3ed91eabb1b663f07c4c084095e60cbed4362dff0d"
+checksum = "94300abf3f1ae2e2b8ffb7b58043de3d399c73fa6f4b73826402a5c457614dbe"
 
 [[package]]
 name = "rustc_version"
@@ -4171,9 +4821,9 @@ dependencies = [
 
 [[package]]
 name = "rustls"
-version = "0.23.37"
+version = "0.23.40"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "758025cb5fccfd3bc2fd74708fd4682be41d99e5dff73c377c0646c6012c73a4"
+checksum = "ef86cd5876211988985292b91c96a8f2d298df24e75989a43a3c73f2d4d8168b"
 dependencies = [
  "aws-lc-rs",
  "log",
@@ -4199,9 +4849,9 @@ dependencies = [
 
 [[package]]
 name = "rustls-pki-types"
-version = "1.14.0"
+version = "1.14.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "be040f8b0a225e40375822a563fa9524378b9d63112f53e19ffff34df5d33fdd"
+checksum = "30a7197ae7eb376e574fe940d068c30fe0462554a3ddbe4eca7838e049c937a9"
 dependencies = [
  "web-time",
  "zeroize",
@@ -4209,9 +4859,9 @@ dependencies = [
 
 [[package]]
 name = "rustls-platform-verifier"
-version = "0.6.2"
+version = "0.7.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "1d99feebc72bae7ab76ba994bb5e121b8d83d910ca40b36e0921f53becc41784"
+checksum = "26d1e2536ce4f35f4846aa13bff16bd0ff40157cdb14cc056c7b14ba41233ba0"
 dependencies = [
  "core-foundation 0.10.1",
  "core-foundation-sys",
@@ -4257,6 +4907,16 @@ name = "ryu"
 version = "1.0.23"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "9774ba4a74de5f7b1c1451ed6cd5285a32eddb5cccb8cc655a4e50009e06477f"
+
+[[package]]
+name = "safetensors"
+version = "0.3.3"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "d93279b86b3de76f820a8854dd06cbc33cfa57a417b19c47f6a25280112fb1df"
+dependencies = [
+ "serde",
+ "serde_json",
+]
 
 [[package]]
 name = "same-file"
@@ -4340,9 +5000,9 @@ dependencies = [
 
 [[package]]
 name = "semver"
-version = "1.0.27"
+version = "1.0.28"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "d767eb0aabc880b29956c35734170f26ed551a859dbd361d140cdbeca61ab1e2"
+checksum = "8a7852d02fc848982e0c167ef163aaff9cd91dc640ba85e263cb1ce46fae51cd"
 
 [[package]]
 name = "seq-macro"
@@ -4405,9 +5065,9 @@ dependencies = [
 
 [[package]]
 name = "serde_spanned"
-version = "1.1.0"
+version = "1.1.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "876ac351060d4f882bb1032b6369eb0aef79ad9df1ea8bc404874d8cc3d0cd98"
+checksum = "6662b5879511e06e8999a8a235d848113e942c9124f211511b16466ee2995f26"
 dependencies = [
  "serde_core",
 ]
@@ -4426,15 +5086,16 @@ dependencies = [
 
 [[package]]
 name = "serde_with"
-version = "3.19.0"
+version = "3.20.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "f05839ce67618e14a09b286535c0d9c94e85ef25469b0e13cb4f844e5593eb19"
+checksum = "e72c1c2cb7b223fafb600a619537a871c2818583d619401b785e7c0b746ccde2"
 dependencies = [
  "base64",
+ "bs58",
  "chrono",
  "hex",
  "indexmap 1.9.3",
- "indexmap 2.13.0",
+ "indexmap 2.14.0",
  "schemars 0.9.0",
  "schemars 1.2.1",
  "serde_core",
@@ -4445,9 +5106,9 @@ dependencies = [
 
 [[package]]
 name = "serde_with_macros"
-version = "3.19.0"
+version = "3.20.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "cf2ebbe86054f9b45bc3881e865683ccfaccce97b9b4cb53f3039d67f355a334"
+checksum = "b90c488738ecb4fb0262f41f43bc40efc5868d9fb744319ddf5f5317f417bfac"
 dependencies = [
  "darling 0.23.0",
  "proc-macro2",
@@ -4525,9 +5186,25 @@ dependencies = [
 
 [[package]]
 name = "simd-adler32"
-version = "0.3.8"
+version = "0.3.9"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "e320a6c5ad31d271ad523dcf3ad13e2767ad8b1cb8f047f75a8aeaf8da139da2"
+checksum = "703d5c7ef118737c72f1af64ad2f6f8c5e1921f818cdcb97b8fe6fc69bf66214"
+
+[[package]]
+name = "simd_cesu8"
+version = "1.1.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "94f90157bb87cddf702797c5dadfa0be7d266cdf49e22da2fcaa32eff75b2c33"
+dependencies = [
+ "rustc_version",
+ "simdutf8",
+]
+
+[[package]]
+name = "simdutf8"
+version = "0.1.5"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "e3a9fe34e3e7a50316060351f37187a3f546bce95496156754b601a5fa71b76e"
 
 [[package]]
 name = "sketches-ddsketch"
@@ -4548,6 +5225,16 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "bdd58c3c93c3d278ca835519292445cb4b0d4dc59ccfdf7ceadaab3f8aeb4038"
 dependencies = [
  "version_check",
+]
+
+[[package]]
+name = "slug"
+version = "0.1.6"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "882a80f72ee45de3cc9a5afeb2da0331d58df69e4e7d8eeb5d3c7784ae67e724"
+dependencies = [
+ "deunicode",
+ "wasm-bindgen",
 ]
 
 [[package]]
@@ -4661,6 +5348,12 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "13c2bddecc57b384dee18652358fb23172facb8a2c51ccc10d74c157bdea3292"
 
 [[package]]
+name = "symlink"
+version = "0.1.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "a7973cce6668464ea31f176d85b13c7ab3bba2cb3b77a2ed26abd7801688010a"
+
+[[package]]
 name = "syn"
 version = "2.0.117"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -4719,6 +5412,20 @@ dependencies = [
 ]
 
 [[package]]
+name = "sysinfo"
+version = "0.38.4"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "92ab6a2f8bfe508deb3c6406578252e491d299cbbf3bc0529ecc3313aee4a52f"
+dependencies = [
+ "libc",
+ "memchr",
+ "ntapi",
+ "objc2-core-foundation",
+ "objc2-io-kit",
+ "windows",
+]
+
+[[package]]
 name = "system-configuration"
 version = "0.7.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -4737,6 +5444,34 @@ checksum = "8e1d1b10ced5ca923a1fcb8d03e96b8d3268065d724548c0211415ff6ac6bac4"
 dependencies = [
  "core-foundation-sys",
  "libc",
+]
+
+[[package]]
+name = "tar"
+version = "0.4.45"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "22692a6476a21fa75fdfc11d452fda482af402c008cdbaf3476414e122040973"
+dependencies = [
+ "filetime",
+ "libc",
+ "xattr",
+]
+
+[[package]]
+name = "tch"
+version = "0.22.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "9e09b91610202dc4820c21eb474a42b386ef69f323b1c0902b5472ba7456ebb5"
+dependencies = [
+ "half",
+ "lazy_static",
+ "libc",
+ "ndarray 0.16.1",
+ "rand 0.8.6",
+ "safetensors",
+ "thiserror 1.0.69",
+ "torch-sys",
+ "zip 0.6.6",
 ]
 
 [[package]]
@@ -4759,6 +5494,17 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "06794f8f6c5c898b3275aebefa6b8a1cb24cd2c6c79397ab15774837a0bc5755"
 dependencies = [
  "winapi-util",
+]
+
+[[package]]
+name = "text_placeholder"
+version = "0.5.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "dd5008f74a09742486ef0047596cf35df2b914e2a8dca5727fcb6ba6842a766b"
+dependencies = [
+ "hashbrown 0.13.2",
+ "serde",
+ "serde_json",
 ]
 
 [[package]]
@@ -4852,9 +5598,9 @@ dependencies = [
 
 [[package]]
 name = "tinystr"
-version = "0.8.2"
+version = "0.8.3"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "42d3e9c45c09de15d06dd8acf5f4e0e399e85927b7f00711024eb7ae10fa4869"
+checksum = "c8323304221c2a851516f22236c5722a72eaa19749016521d6dff0824447d96d"
 dependencies = [
  "displaydoc",
  "zerovec",
@@ -4877,9 +5623,9 @@ checksum = "1f3ccbac311fea05f86f61904b462b55fb3df8837a366dfc601a0161d0532f20"
 
 [[package]]
 name = "tokio"
-version = "1.50.0"
+version = "1.52.3"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "27ad5e34374e03cfffefc301becb44e9dc3c17584f414349ebe29ed26661822d"
+checksum = "8fc7f01b389ac15039e4dc9531aa973a135d7a4135281b12d7c1bc79fd57fffe"
 dependencies = [
  "bytes",
  "libc",
@@ -4892,9 +5638,9 @@ dependencies = [
 
 [[package]]
 name = "tokio-macros"
-version = "2.6.1"
+version = "2.7.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "5c55a2eff8b69ce66c84f85e1da1c233edc36ceb85a2058d11b0d6a3c7e7569c"
+checksum = "385a6cb71ab9ab790c5fe8d67f1645e6c450a7ce006a33de03daa956cf70a496"
 dependencies = [
  "proc-macro2",
  "quote",
@@ -4940,17 +5686,17 @@ dependencies = [
 
 [[package]]
 name = "toml"
-version = "1.1.0+spec-1.1.0"
+version = "1.1.2+spec-1.1.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "f8195ca05e4eb728f4ba94f3e3291661320af739c4e43779cbdfae82ab239fcc"
+checksum = "81f3d15e84cbcd896376e6730314d59fb5a87f31e4b038454184435cd57defee"
 dependencies = [
- "indexmap 2.13.0",
+ "indexmap 2.14.0",
  "serde_core",
  "serde_spanned",
- "toml_datetime 1.1.0+spec-1.1.0",
+ "toml_datetime 1.1.1+spec-1.1.0",
  "toml_parser",
  "toml_writer",
- "winnow 1.0.0",
+ "winnow 1.0.2",
 ]
 
 [[package]]
@@ -4964,39 +5710,54 @@ dependencies = [
 
 [[package]]
 name = "toml_datetime"
-version = "1.1.0+spec-1.1.0"
+version = "1.1.1+spec-1.1.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "97251a7c317e03ad83774a8752a7e81fb6067740609f75ea2b585b569a59198f"
+checksum = "3165f65f62e28e0115a00b2ebdd37eb6f3b641855f9d636d3cd4103767159ad7"
 dependencies = [
  "serde_core",
 ]
 
 [[package]]
 name = "toml_edit"
-version = "0.25.8+spec-1.1.0"
+version = "0.25.11+spec-1.1.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "16bff38f1d86c47f9ff0647e6838d7bb362522bdf44006c7068c2b1e606f1f3c"
+checksum = "0b59c4d22ed448339746c59b905d24568fcbb3ab65a500494f7b8c3e97739f2b"
 dependencies = [
- "indexmap 2.13.0",
- "toml_datetime 1.1.0+spec-1.1.0",
+ "indexmap 2.14.0",
+ "toml_datetime 1.1.1+spec-1.1.0",
  "toml_parser",
- "winnow 1.0.0",
+ "winnow 1.0.2",
 ]
 
 [[package]]
 name = "toml_parser"
-version = "1.1.0+spec-1.1.0"
+version = "1.1.2+spec-1.1.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "2334f11ee363607eb04df9b8fc8a13ca1715a72ba8662a26ac285c98aabb4011"
+checksum = "a2abe9b86193656635d2411dc43050282ca48aa31c2451210f4202550afb7526"
 dependencies = [
- "winnow 1.0.0",
+ "winnow 1.0.2",
 ]
 
 [[package]]
 name = "toml_writer"
-version = "1.1.0+spec-1.1.0"
+version = "1.1.1+spec-1.1.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "d282ade6016312faf3e41e57ebbba0c073e4056dab1232ab1cb624199648f8ed"
+checksum = "756daf9b1013ebe47a8776667b466417e2d4c5679d441c26230efd9ef78692db"
+
+[[package]]
+name = "torch-sys"
+version = "0.22.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "aef40c585e342df95b66a1fa7c923188623999c2b657227befb481dfb03a6a42"
+dependencies = [
+ "anyhow",
+ "cc",
+ "libc",
+ "serde",
+ "serde_json",
+ "ureq 2.12.1",
+ "zip 0.6.6",
+]
 
 [[package]]
 name = "tower"
@@ -5015,20 +5776,20 @@ dependencies = [
 
 [[package]]
 name = "tower-http"
-version = "0.6.8"
+version = "0.6.10"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "d4e6559d53cc268e5031cd8429d05415bc4cb4aefc4aa5d6cc35fbf5b924a1f8"
+checksum = "68d6fdd9f81c2819c9a8b0e0cd91660e7746a8e6ea2ba7c6b2b057985f6bcb51"
 dependencies = [
  "bitflags",
  "bytes",
  "futures-util",
  "http",
  "http-body",
- "iri-string",
  "pin-project-lite",
  "tower",
  "tower-layer",
  "tower-service",
+ "url",
 ]
 
 [[package]]
@@ -5044,10 +5805,89 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "8df9b6e13f2d32c91b9bd719c00d1958837bc7dec474d94952798cc8e69eeec3"
 
 [[package]]
-name = "tracel-xtask"
-version = "4.13.7"
+name = "tracel-llvm"
+version = "20.1.4-7"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "0833b51d15f49423a639836436aa8ce8b11b6c55440dadd1f73a8022381028a5"
+checksum = "982535db9eb1a30ac0f2c50239a0eec3e5cf50993a88e92b04747bd2f4d365b2"
+dependencies = [
+ "tracel-mlir-rs",
+ "tracel-mlir-sys",
+]
+
+[[package]]
+name = "tracel-llvm-bundler"
+version = "20.1.4-7"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "3c75b8e477cb8d49d907afab029ca74d48459f5b88c27bdb4c6cd6acb5e61977"
+dependencies = [
+ "anyhow",
+ "bytes",
+ "constcat",
+ "dirs",
+ "liblzma",
+ "regex",
+ "reqwest 0.12.28",
+ "serde",
+ "serde_json",
+ "sha2",
+ "tar",
+ "walkdir",
+]
+
+[[package]]
+name = "tracel-mlir-rs"
+version = "20.1.4-7"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "77a478a35efd68d0ba73f747adfb7923b121c64e7f5be9cd8364ca1dcb772d5c"
+dependencies = [
+ "tracel-mlir-rs-macros",
+ "tracel-mlir-sys",
+]
+
+[[package]]
+name = "tracel-mlir-rs-macros"
+version = "20.1.4-7"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "7a94f36868c3b10b1825945223d99d106c73f4d249f063caa4651deeb9379344"
+dependencies = [
+ "comrak",
+ "convert_case 0.8.0",
+ "proc-macro2",
+ "quote",
+ "regex",
+ "syn",
+ "tracel-llvm-bundler",
+ "tracel-tblgen-rs",
+ "unindent",
+]
+
+[[package]]
+name = "tracel-mlir-sys"
+version = "20.1.4-7"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "02f26d31af0c225a6d2e3d65d012fd6de848c9fc776897b152ee83b7d1bd15c4"
+dependencies = [
+ "tracel-llvm-bundler",
+]
+
+[[package]]
+name = "tracel-tblgen-rs"
+version = "20.1.4-7"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "00d2581070380418ccc33b500f3739e4d4869421fdb477fcea51ff97c6253a52"
+dependencies = [
+ "bindgen",
+ "cc",
+ "paste",
+ "thiserror 2.0.18",
+ "tracel-llvm-bundler",
+]
+
+[[package]]
+name = "tracel-xtask"
+version = "4.17.2"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "7f3cedee78fe12cc0ebb1a0d2162035900d2dbfd9d6443e08ce28eab44705c8e"
 dependencies = [
  "anyhow",
  "clap",
@@ -5060,7 +5900,7 @@ dependencies = [
  "inquire",
  "log",
  "owo-colors",
- "rand 0.9.2",
+ "rand 0.9.4",
  "regex",
  "serde",
  "serde_json",
@@ -5068,20 +5908,47 @@ dependencies = [
  "time",
  "toml 0.9.12+spec-1.1.0",
  "tracel-xtask-macros",
- "ureq",
- "zip",
+ "tracel-xtask-utils",
+ "ureq 3.3.0",
+ "zip 6.0.0",
 ]
 
 [[package]]
 name = "tracel-xtask-macros"
-version = "4.13.7"
+version = "4.17.2"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "f997d1b36e0d918e4d94f82aeadfd73b5ac11b8870be38e82ff89a9262ccade7"
+checksum = "deb00fe1f051cad8a59d92e7c6f6d2dbd893d1221754ca4f21675fbc699e5e69"
 dependencies = [
  "heck",
  "proc-macro2",
  "quote",
  "syn",
+]
+
+[[package]]
+name = "tracel-xtask-utils"
+version = "4.17.2"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "ef46feabb6e3e260366ba57e44e49f370c7a85ceaedcccb0f048e40b159c559b"
+dependencies = [
+ "anyhow",
+ "clap",
+ "ctrlc",
+ "dotenvy",
+ "env_logger",
+ "home",
+ "inquire",
+ "log",
+ "owo-colors",
+ "rand 0.9.4",
+ "regex",
+ "serde",
+ "serde_json",
+ "strum 0.27.2",
+ "time",
+ "toml 0.9.12+spec-1.1.0",
+ "ureq 3.3.0",
+ "zip 6.0.0",
 ]
 
 [[package]]
@@ -5097,11 +5964,12 @@ dependencies = [
 
 [[package]]
 name = "tracing-appender"
-version = "0.2.4"
+version = "0.2.5"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "786d480bce6247ab75f005b14ae1624ad978d3029d9113f0a22fa1ac773faeaf"
+checksum = "050686193eb999b4bb3bc2acfa891a13da00f79734704c4b8b4ef1a10b368a3c"
 dependencies = [
  "crossbeam-channel",
+ "symlink",
  "thiserror 2.0.18",
  "time",
  "tracing-subscriber",
@@ -5175,7 +6043,7 @@ dependencies = [
  "httparse",
  "log",
  "native-tls",
- "rand 0.9.2",
+ "rand 0.9.4",
  "sha1",
  "thiserror 2.0.18",
  "utf-8",
@@ -5187,7 +6055,7 @@ version = "0.2.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "a21cdb0fc8f85c98b1ec812bc4cd69faf6c0fa2fc17d44ea3c2cdd38dc08e999"
 dependencies = [
- "nom",
+ "nom 8.0.0",
 ]
 
 [[package]]
@@ -5196,14 +6064,20 @@ version = "0.5.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "cb30dbbd9036155e74adad6812e9898d03ec374946234fbcebd5dfc7b9187b90"
 dependencies = [
- "rustc-hash 2.1.1",
+ "rustc-hash 2.1.2",
 ]
 
 [[package]]
-name = "typenum"
-version = "1.19.0"
+name = "typed-arena"
+version = "2.0.2"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "562d481066bde0658276a35467c4af00bdc6ee726305698a55b86e61d7ad82bb"
+checksum = "6af6ae20167a9ece4bcb41af5b80f8a1f1df981f6391189ce00fd257af04126a"
+
+[[package]]
+name = "typenum"
+version = "1.20.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "40ce102ab67701b8526c123c1bab5cbe42d7040ccfd0f64af1a385808d2f43de"
 
 [[package]]
 name = "unicode-ident"
@@ -5212,10 +6086,19 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "e6e4313cd5fcd3dad5cafa179702e2b244f760991f45397d14d4ebf38247da75"
 
 [[package]]
-name = "unicode-segmentation"
-version = "1.13.0"
+name = "unicode-normalization"
+version = "0.1.25"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "a559e63b5d8004e12f9bce88af5c6d939c58de839b7532cfe9653846cedd2a9e"
+checksum = "5fd4f6878c9cb28d874b009da9e8d183b5abc80117c40bbd187a1fde336be6e8"
+dependencies = [
+ "tinyvec",
+]
+
+[[package]]
+name = "unicode-segmentation"
+version = "1.13.2"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "9629274872b2bfaf8d66f5f15725007f635594914870f65218920345aa11aa8c"
 
 [[package]]
 name = "unicode-width"
@@ -5230,6 +6113,18 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "ebc1c04c71510c7f702b52b7c350734c9ff1295c464a03335b00bb84fc54f853"
 
 [[package]]
+name = "unicode_categories"
+version = "0.1.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "39ec24b3121d976906ece63c9daad25b85969647682eee313cb5779fdd69e14e"
+
+[[package]]
+name = "unindent"
+version = "0.2.4"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "7264e107f553ccae879d21fbea1d6724ac785e8c3bfc762137959b5802826ef3"
+
+[[package]]
 name = "untrusted"
 version = "0.9.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -5240,6 +6135,24 @@ name = "unty"
 version = "0.0.4"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "6d49784317cd0d1ee7ec5c716dd598ec5b4483ea832a2dced265471cc0f690ae"
+
+[[package]]
+name = "ureq"
+version = "2.12.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "02d1a66277ed75f640d608235660df48c8e3c19f3b4edb6a263315626cc3c01d"
+dependencies = [
+ "base64",
+ "flate2",
+ "log",
+ "once_cell",
+ "rustls",
+ "rustls-pki-types",
+ "serde",
+ "serde_json",
+ "url",
+ "webpki-roots 0.26.11",
+]
 
 [[package]]
 name = "ureq"
@@ -5258,7 +6171,7 @@ dependencies = [
  "serde_json",
  "ureq-proto",
  "utf8-zero",
- "webpki-roots",
+ "webpki-roots 1.0.7",
 ]
 
 [[package]]
@@ -5381,11 +6294,11 @@ checksum = "ccf3ec651a847eb01de73ccad15eb7d99f80485de043efb2f370cd654f4ea44b"
 
 [[package]]
 name = "wasip2"
-version = "1.0.2+wasi-0.2.9"
+version = "1.0.3+wasi-0.2.9"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "9517f9239f02c069db75e65f174b3da828fe5f5b945c4dd26bd25d89c03ebcf5"
+checksum = "20064672db26d7cdc89c7798c48a0fdfac8213434a1186e5ef29fd560ae223d6"
 dependencies = [
- "wit-bindgen",
+ "wit-bindgen 0.57.1",
 ]
 
 [[package]]
@@ -5394,14 +6307,14 @@ version = "0.4.0+wasi-0.3.0-rc-2026-01-06"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "5428f8bf88ea5ddc08faddef2ac4a67e390b88186c703ce6dbd955e1c145aca5"
 dependencies = [
- "wit-bindgen",
+ "wit-bindgen 0.51.0",
 ]
 
 [[package]]
 name = "wasm-bindgen"
-version = "0.2.114"
+version = "0.2.121"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "6532f9a5c1ece3798cb1c2cfdba640b9b3ba884f5db45973a6f442510a87d38e"
+checksum = "49ace1d07c165b0864824eee619580c4689389afa9dc9ed3a4c75040d82e6790"
 dependencies = [
  "cfg-if",
  "once_cell",
@@ -5412,23 +6325,19 @@ dependencies = [
 
 [[package]]
 name = "wasm-bindgen-futures"
-version = "0.4.64"
+version = "0.4.71"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "e9c5522b3a28661442748e09d40924dfb9ca614b21c00d3fd135720e48b67db8"
+checksum = "96492d0d3ffba25305a7dc88720d250b1401d7edca02cc3bcd50633b424673b8"
 dependencies = [
- "cfg-if",
- "futures-util",
  "js-sys",
- "once_cell",
  "wasm-bindgen",
- "web-sys",
 ]
 
 [[package]]
 name = "wasm-bindgen-macro"
-version = "0.2.114"
+version = "0.2.121"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "18a2d50fcf105fb33bb15f00e7a77b772945a2ee45dcf454961fd843e74c18e6"
+checksum = "8e68e6f4afd367a562002c05637acb8578ff2dea1943df76afb9e83d177c8578"
 dependencies = [
  "quote",
  "wasm-bindgen-macro-support",
@@ -5436,9 +6345,9 @@ dependencies = [
 
 [[package]]
 name = "wasm-bindgen-macro-support"
-version = "0.2.114"
+version = "0.2.121"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "03ce4caeaac547cdf713d280eda22a730824dd11e6b8c3ca9e42247b25c631e3"
+checksum = "d95a9ec35c64b2a7cb35d3fead40c4238d0940c86d107136999567a4703259f2"
 dependencies = [
  "bumpalo",
  "proc-macro2",
@@ -5449,9 +6358,9 @@ dependencies = [
 
 [[package]]
 name = "wasm-bindgen-shared"
-version = "0.2.114"
+version = "0.2.121"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "75a326b8c223ee17883a4251907455a2431acc2791c98c26279376490c378c16"
+checksum = "c4e0100b01e9f0d03189a92b96772a1fb998639d981193d7dbab487302513441"
 dependencies = [
  "unicode-ident",
 ]
@@ -5473,7 +6382,7 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "bb0e353e6a2fbdc176932bbaab493762eb1255a7900fe0fea1a2f96c296cc909"
 dependencies = [
  "anyhow",
- "indexmap 2.13.0",
+ "indexmap 2.14.0",
  "wasm-encoder",
  "wasmparser",
 ]
@@ -5486,7 +6395,7 @@ checksum = "47b807c72e1bac69382b3a6fb3dbe8ea4c0ed87ff5629b8685ae6b9a611028fe"
 dependencies = [
  "bitflags",
  "hashbrown 0.15.5",
- "indexmap 2.13.0",
+ "indexmap 2.14.0",
  "semver",
 ]
 
@@ -5504,9 +6413,9 @@ dependencies = [
 
 [[package]]
 name = "web-sys"
-version = "0.3.91"
+version = "0.3.98"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "854ba17bb104abfb26ba36da9729addc7ce7f06f5c0f90f3c391f8461cca21f9"
+checksum = "4b572dff8bcf38bad0fa19729c89bb5748b2b9b1d8be70cf90df697e3a8f32aa"
 dependencies = [
  "js-sys",
  "wasm-bindgen",
@@ -5524,18 +6433,27 @@ dependencies = [
 
 [[package]]
 name = "webpki-root-certs"
-version = "1.0.6"
+version = "1.0.7"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "804f18a4ac2676ffb4e8b5b5fa9ae38af06df08162314f96a68d2a363e21a8ca"
+checksum = "f31141ce3fc3e300ae89b78c0dd67f9708061d1d2eda54b8209346fd6be9a92c"
 dependencies = [
  "rustls-pki-types",
 ]
 
 [[package]]
 name = "webpki-roots"
-version = "1.0.6"
+version = "0.26.11"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "22cfaf3c063993ff62e73cb4311efde4db1efb31ab78a3e5c457939ad5cc0bed"
+checksum = "521bc38abb08001b01866da9f51eb7c5d647a19260e00054a8c7fd5f9e57f7a9"
+dependencies = [
+ "webpki-roots 1.0.7",
+]
+
+[[package]]
+name = "webpki-roots"
+version = "1.0.7"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "52f5ee44c96cf55f1b349600768e3ece3a8f26010c05265ab73f945bb1a2eb9d"
 dependencies = [
  "rustls-pki-types",
 ]
@@ -5584,7 +6502,7 @@ dependencies = [
  "cfg_aliases",
  "document-features",
  "hashbrown 0.16.1",
- "indexmap 2.13.0",
+ "indexmap 2.14.0",
  "log",
  "naga",
  "once_cell",
@@ -5679,9 +6597,9 @@ dependencies = [
  "web-sys",
  "wgpu-naga-bridge",
  "wgpu-types",
- "windows 0.62.2",
- "windows-core 0.62.2",
- "windows-result 0.4.1",
+ "windows",
+ "windows-core",
+ "windows-result",
 ]
 
 [[package]]
@@ -5741,22 +6659,12 @@ checksum = "712e227841d057c1ee1cd2fb22fa7e5a5461ae8e48fa2ca79ec42cfc1931183f"
 
 [[package]]
 name = "windows"
-version = "0.58.0"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "dd04d41d93c4992d421894c18c8b43496aa748dd4c081bac0dc93eb0489272b6"
-dependencies = [
- "windows-core 0.58.0",
- "windows-targets 0.52.6",
-]
-
-[[package]]
-name = "windows"
 version = "0.62.2"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "527fadee13e0c05939a6a05d5bd6eec6cd2e3dbd648b9f8e447c6518133d8580"
 dependencies = [
  "windows-collections",
- "windows-core 0.62.2",
+ "windows-core",
  "windows-future",
  "windows-numerics",
 ]
@@ -5767,20 +6675,7 @@ version = "0.3.2"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "23b2d95af1a8a14a3c7367e1ed4fc9c20e0a26e79551b1454d72583c97cc6610"
 dependencies = [
- "windows-core 0.62.2",
-]
-
-[[package]]
-name = "windows-core"
-version = "0.58.0"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "6ba6d44ec8c2591c134257ce647b7ea6b20335bf6379a27dac5f1641fcf59f99"
-dependencies = [
- "windows-implement 0.58.0",
- "windows-interface 0.58.0",
- "windows-result 0.2.0",
- "windows-strings 0.1.0",
- "windows-targets 0.52.6",
+ "windows-core",
 ]
 
 [[package]]
@@ -5789,11 +6684,11 @@ version = "0.62.2"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "b8e83a14d34d0623b51dce9581199302a221863196a1dde71a7663a4c2be9deb"
 dependencies = [
- "windows-implement 0.60.2",
- "windows-interface 0.59.3",
+ "windows-implement",
+ "windows-interface",
  "windows-link",
- "windows-result 0.4.1",
- "windows-strings 0.5.1",
+ "windows-result",
+ "windows-strings",
 ]
 
 [[package]]
@@ -5802,20 +6697,9 @@ version = "0.3.2"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "e1d6f90251fe18a279739e78025bd6ddc52a7e22f921070ccdc67dde84c605cb"
 dependencies = [
- "windows-core 0.62.2",
+ "windows-core",
  "windows-link",
  "windows-threading",
-]
-
-[[package]]
-name = "windows-implement"
-version = "0.58.0"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "2bbd5b46c938e506ecbce286b6628a02171d56153ba733b6c741fc627ec9579b"
-dependencies = [
- "proc-macro2",
- "quote",
- "syn",
 ]
 
 [[package]]
@@ -5823,17 +6707,6 @@ name = "windows-implement"
 version = "0.60.2"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "053e2e040ab57b9dc951b72c264860db7eb3b0200ba345b4e4c3b14f67855ddf"
-dependencies = [
- "proc-macro2",
- "quote",
- "syn",
-]
-
-[[package]]
-name = "windows-interface"
-version = "0.58.0"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "053c4c462dc91d3b1504c6fe5a726dd15e216ba718e84a0e46a88fbe5ded3515"
 dependencies = [
  "proc-macro2",
  "quote",
@@ -5863,7 +6736,7 @@ version = "0.3.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "6e2e40844ac143cdb44aead537bbf727de9b044e107a0f1220392177d15b0f26"
 dependencies = [
- "windows-core 0.62.2",
+ "windows-core",
  "windows-link",
 ]
 
@@ -5874,17 +6747,8 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "02752bf7fbdcce7f2a27a742f798510f3e5ad88dbe84871e5168e2120c3d5720"
 dependencies = [
  "windows-link",
- "windows-result 0.4.1",
- "windows-strings 0.5.1",
-]
-
-[[package]]
-name = "windows-result"
-version = "0.2.0"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "1d1043d8214f791817bab27572aaa8af63732e11bf84aa21a45a78d6c317ae0e"
-dependencies = [
- "windows-targets 0.52.6",
+ "windows-result",
+ "windows-strings",
 ]
 
 [[package]]
@@ -5898,30 +6762,11 @@ dependencies = [
 
 [[package]]
 name = "windows-strings"
-version = "0.1.0"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "4cd9b125c486025df0eabcb585e62173c6c9eddcec5d117d3b6e8c30e2ee4d10"
-dependencies = [
- "windows-result 0.2.0",
- "windows-targets 0.52.6",
-]
-
-[[package]]
-name = "windows-strings"
 version = "0.5.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "7837d08f69c77cf6b07689544538e017c1bfcf57e34b4c0ff58e6c2cd3b37091"
 dependencies = [
  "windows-link",
-]
-
-[[package]]
-name = "windows-sys"
-version = "0.45.0"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "75283be5efb2831d37ea142365f009c02ec203cd29a3ebecbc093d52315b66d0"
-dependencies = [
- "windows-targets 0.42.2",
 ]
 
 [[package]]
@@ -5949,21 +6794,6 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "ae137229bcbd6cdf0f7b80a31df61766145077ddf49416a728b02cb3921ff3fc"
 dependencies = [
  "windows-link",
-]
-
-[[package]]
-name = "windows-targets"
-version = "0.42.2"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "8e5180c00cd44c9b1c88adb3693291f1cd93605ded80c250a75d472756b4d071"
-dependencies = [
- "windows_aarch64_gnullvm 0.42.2",
- "windows_aarch64_msvc 0.42.2",
- "windows_i686_gnu 0.42.2",
- "windows_i686_msvc 0.42.2",
- "windows_x86_64_gnu 0.42.2",
- "windows_x86_64_gnullvm 0.42.2",
- "windows_x86_64_msvc 0.42.2",
 ]
 
 [[package]]
@@ -6010,12 +6840,6 @@ dependencies = [
 
 [[package]]
 name = "windows_aarch64_gnullvm"
-version = "0.42.2"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "597a5118570b68bc08d8d59125332c54f1ba9d9adeedeef5b99b02ba2b0698f8"
-
-[[package]]
-name = "windows_aarch64_gnullvm"
 version = "0.52.6"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "32a4622180e7a0ec044bb555404c800bc9fd9ec262ec147edd5989ccd0c02cd3"
@@ -6028,12 +6852,6 @@ checksum = "a9d8416fa8b42f5c947f8482c43e7d89e73a173cead56d044f6a56104a6d1b53"
 
 [[package]]
 name = "windows_aarch64_msvc"
-version = "0.42.2"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "e08e8864a60f06ef0d0ff4ba04124db8b0fb3be5776a5cd47641e942e58c4d43"
-
-[[package]]
-name = "windows_aarch64_msvc"
 version = "0.52.6"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "09ec2a7bb152e2252b53fa7803150007879548bc709c039df7627cabbd05d469"
@@ -6043,12 +6861,6 @@ name = "windows_aarch64_msvc"
 version = "0.53.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "b9d782e804c2f632e395708e99a94275910eb9100b2114651e04744e9b125006"
-
-[[package]]
-name = "windows_i686_gnu"
-version = "0.42.2"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "c61d927d8da41da96a81f029489353e68739737d3beca43145c8afec9a31a84f"
 
 [[package]]
 name = "windows_i686_gnu"
@@ -6076,12 +6888,6 @@ checksum = "fa7359d10048f68ab8b09fa71c3daccfb0e9b559aed648a8f95469c27057180c"
 
 [[package]]
 name = "windows_i686_msvc"
-version = "0.42.2"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "44d840b6ec649f480a41c8d80f9c65108b92d89345dd94027bfe06ac444d1060"
-
-[[package]]
-name = "windows_i686_msvc"
 version = "0.52.6"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "240948bc05c5e7c6dabba28bf89d89ffce3e303022809e73deaefe4f6ec56c66"
@@ -6091,12 +6897,6 @@ name = "windows_i686_msvc"
 version = "0.53.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "1e7ac75179f18232fe9c285163565a57ef8d3c89254a30685b57d83a38d326c2"
-
-[[package]]
-name = "windows_x86_64_gnu"
-version = "0.42.2"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "8de912b8b8feb55c064867cf047dda097f92d51efad5b491dfb98f6bbb70cb36"
 
 [[package]]
 name = "windows_x86_64_gnu"
@@ -6112,12 +6912,6 @@ checksum = "9c3842cdd74a865a8066ab39c8a7a473c0778a3f29370b5fd6b4b9aa7df4a499"
 
 [[package]]
 name = "windows_x86_64_gnullvm"
-version = "0.42.2"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "26d41b46a36d453748aedef1486d5c7a85db22e56aff34643984ea85514e94a3"
-
-[[package]]
-name = "windows_x86_64_gnullvm"
 version = "0.52.6"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "24d5b23dc417412679681396f2b49f3de8c1473deb516bd34410872eff51ed0d"
@@ -6127,12 +6921,6 @@ name = "windows_x86_64_gnullvm"
 version = "0.53.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "0ffa179e2d07eee8ad8f57493436566c7cc30ac536a3379fdf008f47f6bb7ae1"
-
-[[package]]
-name = "windows_x86_64_msvc"
-version = "0.42.2"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "9aec5da331524158c6d1a4ac0ab1541149c0b9505fde06423b02f5ef0106b9f0"
 
 [[package]]
 name = "windows_x86_64_msvc"
@@ -6154,9 +6942,9 @@ checksum = "df79d97927682d2fd8adb29682d1140b343be4ac0f08fd68b7765d9c059d3945"
 
 [[package]]
 name = "winnow"
-version = "1.0.0"
+version = "1.0.2"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "a90e88e4667264a994d34e6d1ab2d26d398dcdca8b7f52bec8668957517fc7d8"
+checksum = "2ee1708bef14716a11bae175f579062d4554d95be2c6829f518df847b7b3fdd0"
 dependencies = [
  "memchr",
 ]
@@ -6169,6 +6957,12 @@ checksum = "d7249219f66ced02969388cf2bb044a09756a083d0fab1e566056b04d9fbcaa5"
 dependencies = [
  "wit-bindgen-rust-macro",
 ]
+
+[[package]]
+name = "wit-bindgen"
+version = "0.57.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "1ebf944e87a7c253233ad6766e082e3cd714b5d03812acc24c318f549614536e"
 
 [[package]]
 name = "wit-bindgen-core"
@@ -6189,7 +6983,7 @@ checksum = "b7c566e0f4b284dd6561c786d9cb0142da491f46a9fbed79ea69cdad5db17f21"
 dependencies = [
  "anyhow",
  "heck",
- "indexmap 2.13.0",
+ "indexmap 2.14.0",
  "prettyplease",
  "syn",
  "wasm-metadata",
@@ -6220,7 +7014,7 @@ checksum = "9d66ea20e9553b30172b5e831994e35fbde2d165325bec84fc43dbf6f4eb9cb2"
 dependencies = [
  "anyhow",
  "bitflags",
- "indexmap 2.13.0",
+ "indexmap 2.14.0",
  "log",
  "serde",
  "serde_derive",
@@ -6239,7 +7033,7 @@ checksum = "ecc8ac4bc1dc3381b7f59c34f00b67e18f910c2c0f50015669dde7def656a736"
 dependencies = [
  "anyhow",
  "id-arena",
- "indexmap 2.13.0",
+ "indexmap 2.14.0",
  "log",
  "semver",
  "serde",
@@ -6251,9 +7045,19 @@ dependencies = [
 
 [[package]]
 name = "writeable"
-version = "0.6.2"
+version = "0.6.3"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "9edde0db4769d2dc68579893f2306b26c6ecfbe0ef499b013d731b7b9247e0b9"
+checksum = "1ffae5123b2d3fc086436f8834ae3ab053a283cfac8fe0a0b8eaae044768a4c4"
+
+[[package]]
+name = "xattr"
+version = "1.6.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "32e45ad4206f6d2479085147f02bc2ef834ac85886624a23575ae137c8aa8156"
+dependencies = [
+ "libc",
+ "rustix",
+]
 
 [[package]]
 name = "xml-rs"
@@ -6278,9 +7082,9 @@ checksum = "fdd20c5420375476fbd4394763288da7eb0cc0b8c11deed431a91562af7335d3"
 
 [[package]]
 name = "yoke"
-version = "0.8.1"
+version = "0.8.2"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "72d6e5c6afb84d73944e5cedb052c4680d5657337201555f9f2a16b7406d4954"
+checksum = "abe8c5fda708d9ca3df187cae8bfb9ceda00dd96231bed36e445a1a48e66f9ca"
 dependencies = [
  "stable_deref_trait",
  "yoke-derive",
@@ -6289,9 +7093,9 @@ dependencies = [
 
 [[package]]
 name = "yoke-derive"
-version = "0.8.1"
+version = "0.8.2"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "b659052874eb698efe5b9e8cf382204678a0086ebf46982b79d6ca3182927e5d"
+checksum = "de844c262c8848816172cef550288e7dc6c7b7814b4ee56b3e1553f275f1858e"
 dependencies = [
  "proc-macro2",
  "quote",
@@ -6301,18 +7105,18 @@ dependencies = [
 
 [[package]]
 name = "zerocopy"
-version = "0.8.47"
+version = "0.8.48"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "efbb2a062be311f2ba113ce66f697a4dc589f85e78a4aea276200804cea0ed87"
+checksum = "eed437bf9d6692032087e337407a86f04cd8d6a16a37199ed57949d415bd68e9"
 dependencies = [
  "zerocopy-derive",
 ]
 
 [[package]]
 name = "zerocopy-derive"
-version = "0.8.47"
+version = "0.8.48"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "0e8bc7269b54418e7aeeef514aa68f8690b8c0489a06b0136e5f57c4c5ccab89"
+checksum = "70e3cd084b1788766f53af483dd21f93881ff30d7320490ec3ef7526d203bad4"
 dependencies = [
  "proc-macro2",
  "quote",
@@ -6321,18 +7125,18 @@ dependencies = [
 
 [[package]]
 name = "zerofrom"
-version = "0.1.6"
+version = "0.1.8"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "50cc42e0333e05660c3587f3bf9d0478688e15d870fab3346451ce7f8c9fbea5"
+checksum = "0ec05a11813ea801ff6d75110ad09cd0824ddba17dfe17128ea0d5f68e6c5272"
 dependencies = [
  "zerofrom-derive",
 ]
 
 [[package]]
 name = "zerofrom-derive"
-version = "0.1.6"
+version = "0.1.7"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "d71e5d6e06ab090c67b5e44993ec16b72dcbaabc526db883a360057678b48502"
+checksum = "11532158c46691caf0f2593ea8358fed6bbf68a0315e80aae9bd41fbade684a1"
 dependencies = [
  "proc-macro2",
  "quote",
@@ -6362,9 +7166,9 @@ dependencies = [
 
 [[package]]
 name = "zerotrie"
-version = "0.2.3"
+version = "0.2.4"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "2a59c17a5562d507e4b54960e8569ebee33bee890c70aa3fe7b97e85a9fd7851"
+checksum = "0f9152d31db0792fa83f70fb2f83148effb5c1f5b8c7686c3459e361d9bc20bf"
 dependencies = [
  "displaydoc",
  "yoke",
@@ -6373,9 +7177,9 @@ dependencies = [
 
 [[package]]
 name = "zerovec"
-version = "0.11.5"
+version = "0.11.6"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "6c28719294829477f525be0186d13efa9a3c602f7ec202ca9e353d310fb9a002"
+checksum = "90f911cbc359ab6af17377d242225f4d75119aec87ea711a880987b18cd7b239"
 dependencies = [
  "yoke",
  "zerofrom",
@@ -6384,13 +7188,33 @@ dependencies = [
 
 [[package]]
 name = "zerovec-derive"
-version = "0.11.2"
+version = "0.11.3"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "eadce39539ca5cb3985590102671f2567e659fca9666581ad3411d59207951f3"
+checksum = "625dc425cab0dca6dc3c3319506e6593dcb08a9f387ea3b284dbd52a92c40555"
 dependencies = [
  "proc-macro2",
  "quote",
  "syn",
+]
+
+[[package]]
+name = "zip"
+version = "0.6.6"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "760394e246e4c28189f19d488c058bf16f564016aefac5d32bb1f3b51d5e9261"
+dependencies = [
+ "aes",
+ "byteorder",
+ "bzip2 0.4.4",
+ "constant_time_eq 0.1.5",
+ "crc32fast",
+ "crossbeam-utils",
+ "flate2",
+ "hmac",
+ "pbkdf2 0.11.0",
+ "sha1",
+ "time",
+ "zstd 0.11.2+zstd.1.5.2",
 ]
 
 [[package]]
@@ -6401,23 +7225,23 @@ checksum = "eb2a05c7c36fde6c09b08576c9f7fb4cda705990f73b58fe011abf7dfb24168b"
 dependencies = [
  "aes",
  "arbitrary",
- "bzip2",
- "constant_time_eq",
+ "bzip2 0.6.1",
+ "constant_time_eq 0.3.1",
  "crc32fast",
  "deflate64",
  "flate2",
  "getrandom 0.3.4",
  "hmac",
- "indexmap 2.13.0",
+ "indexmap 2.14.0",
  "lzma-rust2",
  "memchr",
- "pbkdf2",
+ "pbkdf2 0.12.2",
  "ppmd-rust",
  "sha1",
  "time",
  "zeroize",
  "zopfli",
- "zstd",
+ "zstd 0.13.3",
 ]
 
 [[package]]
@@ -6446,11 +7270,30 @@ dependencies = [
 
 [[package]]
 name = "zstd"
+version = "0.11.2+zstd.1.5.2"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "20cc960326ece64f010d2d2107537f26dc589a6573a316bd5b1dba685fa5fde4"
+dependencies = [
+ "zstd-safe 5.0.2+zstd.1.5.2",
+]
+
+[[package]]
+name = "zstd"
 version = "0.13.3"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "e91ee311a569c327171651566e07972200e76fcfe2242a4fa446149a3881c08a"
 dependencies = [
- "zstd-safe",
+ "zstd-safe 7.2.4",
+]
+
+[[package]]
+name = "zstd-safe"
+version = "5.0.2+zstd.1.5.2"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "1d2a5585e04f9eea4b2a3d1eca508c4dee9592a89ef6f450c11719da0726f4db"
+dependencies = [
+ "libc",
+ "zstd-sys",
 ]
 
 [[package]]

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -18,7 +18,7 @@ keywords = ["tracel", "burn-central", "burn", "sdk"]
 categories = ["development-tools"]
 
 [workspace.dependencies]
-burn = { git = "https://github.com/tracel-ai/burn", rev = "dbf03c516bac61efa3186ba9cafdb92ddf294021", default-features = false, features = [
+burn = { git = "https://github.com/tracel-ai/burn", rev = "924d5d9ee9f87c411a103e1178a9baeb3e6c3f1a", default-features = false, features = [
     "train",
 ] }
 

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -18,7 +18,9 @@ keywords = ["tracel", "burn-central", "burn", "sdk"]
 categories = ["development-tools"]
 
 [workspace.dependencies]
-burn = { version = "0.21.0", default-features = false, features = ["train"] }
+burn = { git = "https://github.com/tracel-ai/burn", rev = "dbf03c516bac61efa3186ba9cafdb92ddf294021", default-features = false, features = [
+    "train",
+] }
 
 url = "2.5.8"
 anyhow = "1.0.101"

--- a/crates/burn-central-experiment/Cargo.toml
+++ b/crates/burn-central-experiment/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "burn-central-experiment"
-description = "Backend-agnostic experiment tracking for Burn Central and local runs"
+description = "Experiment tracking primitives for Burn Central and local runs"
 edition.workspace = true
 version.workspace = true
 readme.workspace = true

--- a/crates/burn-central-experiment/src/integration/training/checkpoint.rs
+++ b/crates/burn-central-experiment/src/integration/training/checkpoint.rs
@@ -6,22 +6,18 @@ use crate::ExperimentRunHandle;
 use burn::record::{
     FileRecorder, FullPrecisionSettings, NamedMpkBytesRecorder, Record, Recorder, RecorderError,
 };
-use burn::tensor::backend::Backend;
+use burn::tensor::Device;
 use burn_central_artifact::bundle::{BundleDecode, BundleEncode, BundleSink, BundleSource};
 use serde::Deserialize;
 use serde::{Serialize, de::DeserializeOwned};
 
-struct CheckpointRecordSources<B, R> {
-    pub backend: std::marker::PhantomData<B>,
+struct CheckpointRecordSources<R> {
     pub record: R,
 }
 
-impl<B, R> CheckpointRecordSources<B, R> {
+impl<R> CheckpointRecordSources<R> {
     pub fn new(record: R) -> Self {
-        Self {
-            backend: std::marker::PhantomData,
-            record,
-        }
+        Self { record }
     }
 }
 
@@ -38,10 +34,9 @@ impl Default for CheckpointRecordArtifactSettings {
     }
 }
 
-impl<B, R> BundleEncode for CheckpointRecordSources<B, R>
+impl<R> BundleEncode for CheckpointRecordSources<R>
 where
-    R: Record<B>,
-    B: Backend,
+    R: Record,
 {
     type Settings = CheckpointRecordArtifactSettings;
     type Error = String;
@@ -60,10 +55,9 @@ where
     }
 }
 
-impl<B, R> BundleDecode for CheckpointRecordSources<B, R>
+impl<R> BundleDecode for CheckpointRecordSources<R>
 where
-    R: Record<B>,
-    B: Backend,
+    R: Record,
 {
     type Settings = CheckpointRecordArtifactSettings;
     type Error = String;
@@ -84,7 +78,7 @@ where
         })?;
         let recorder = NamedMpkBytesRecorder::<FullPrecisionSettings>::default();
         let record = recorder
-            .load::<R>(bytes, &B::Device::default())
+            .load::<R>(bytes, &Device::default())
             .map_err(|e| format!("Failed to load record from bytes: {}", e))?;
         Ok(Self::new(record))
     }
@@ -115,7 +109,7 @@ impl ExperimentCheckpointRecorder {
     }
 }
 
-impl<B: Backend> FileRecorder<B> for ExperimentCheckpointRecorder {
+impl FileRecorder for ExperimentCheckpointRecorder {
     fn file_extension() -> &'static str {
         "mpk"
     }
@@ -129,7 +123,7 @@ impl Default for ExperimentCheckpointRecorder {
     }
 }
 
-impl<B: Backend> Recorder<B> for ExperimentCheckpointRecorder {
+impl Recorder for ExperimentCheckpointRecorder {
     type Settings = FullPrecisionSettings;
     type RecordArgs = PathBuf;
     type RecordOutput = ();
@@ -141,7 +135,7 @@ impl<B: Backend> Recorder<B> for ExperimentCheckpointRecorder {
         args: Self::RecordArgs,
     ) -> Result<Self::RecordOutput, RecorderError>
     where
-        R: Record<B>,
+        R: Record,
     {
         let file_name = args
             .file_name()
@@ -165,9 +159,9 @@ impl<B: Backend> Recorder<B> for ExperimentCheckpointRecorder {
             .map_err(|e| RecorderError::Unknown(format!("Failed to record artifact: {e}")))
     }
 
-    fn load<R>(&self, args: Self::LoadArgs, _device: &B::Device) -> Result<R, RecorderError>
+    fn load<R>(&self, args: Self::LoadArgs, _device: &Device) -> Result<R, RecorderError>
     where
-        R: Record<B>,
+        R: Record,
     {
         let name = args
             .file_name()
@@ -184,7 +178,7 @@ impl<B: Backend> Recorder<B> for ExperimentCheckpointRecorder {
         };
         let artifact = self
             .experiment_handle
-            .use_artifact::<CheckpointRecordSources<B, R>>(
+            .use_artifact::<CheckpointRecordSources<R>>(
                 self.experiment_handle.id().clone(),
                 name,
                 &settings,

--- a/crates/burn-central-experiment/src/lib.rs
+++ b/crates/burn-central-experiment/src/lib.rs
@@ -1,4 +1,4 @@
-//! Backend-agnostic experiment tracking primitives.
+//! Experiment tracking primitives.
 //!
 //! This crate revolves around two core types:
 //! - [`ExperimentRun`], which owns the lifecycle of an active experiment.

--- a/crates/burn-central-experiment/src/session.rs
+++ b/crates/burn-central-experiment/src/session.rs
@@ -50,7 +50,7 @@ pub enum ExperimentCompletion {
 
 pub type BundleFn<'a> = dyn FnOnce(&mut FsBundle) -> Result<(), ExperimentError> + 'a;
 
-/// Backend-specific implementation for the active experiment run.
+/// Session-level implementation for the active experiment run.
 pub trait ExperimentSession: Send + Sync {
     fn record_event(&self, event: Event) -> Result<(), ExperimentError>;
     fn save_artifact(

--- a/crates/burn-central-fleet/Cargo.toml
+++ b/crates/burn-central-fleet/Cargo.toml
@@ -12,7 +12,6 @@ license.workspace = true
 rust-version.workspace = true
 
 [dependencies]
-burn.workspace = true
 burn-central-client.workspace = true
 burn-central-inference.workspace = true
 burn-central-artifact.workspace = true

--- a/crates/burn-central-fleet/src/inference.rs
+++ b/crates/burn-central-fleet/src/inference.rs
@@ -2,7 +2,6 @@ use std::sync::{Arc, Mutex, RwLock};
 use std::time::{Duration, Instant};
 
 use arc_swap::ArcSwapOption;
-use burn::tensor::Device;
 use burn_central_artifact::bundle::FsBundle;
 use burn_central_inference::{Inference, InferenceWriter};
 
@@ -16,25 +15,20 @@ pub enum FleetManagedInferenceError {
 }
 
 pub trait FleetManagedFactory<I>: Send + Sync {
-    fn build(
-        &self,
-        model_source: FsBundle,
-        runtime_config: serde_json::Value,
-        device: Device,
-    ) -> Result<I, String>;
+    fn build(&self, model_source: FsBundle, runtime_config: serde_json::Value)
+    -> Result<I, String>;
 }
 
 impl<F, I> FleetManagedFactory<I> for F
 where
-    F: Fn(FsBundle, serde_json::Value, Device) -> Result<I, String> + Send + Sync,
+    F: Fn(FsBundle, serde_json::Value) -> Result<I, String> + Send + Sync,
 {
     fn build(
         &self,
         model_source: FsBundle,
         runtime_config: serde_json::Value,
-        device: Device,
     ) -> Result<I, String> {
-        self(model_source, runtime_config, device)
+        self(model_source, runtime_config)
     }
 }
 
@@ -48,7 +42,6 @@ pub struct FleetManagedInference<I> {
     inference_name: String,
     fleet_session: RwLock<FleetDeviceSession>,
     factory: Box<dyn FleetManagedFactory<I>>,
-    device: Device,
     active: ArcSwapOption<ActiveInference<I>>,
     reconcile_gate: Mutex<()>,
     last_sync_at: Mutex<Option<Instant>>,
@@ -63,13 +56,11 @@ where
         inference_name: impl Into<String>,
         fleet_session: FleetDeviceSession,
         factory: Box<dyn FleetManagedFactory<I>>,
-        device: Device,
     ) -> Result<Self, FleetManagedInferenceError> {
         let inference = Self {
             inference_name: inference_name.into(),
             fleet_session: RwLock::new(fleet_session),
             factory,
-            device,
             active: ArcSwapOption::empty(),
             reconcile_gate: Mutex::new(()),
             last_sync_at: Mutex::new(None),
@@ -151,7 +142,7 @@ where
 
         let built = self
             .factory
-            .build(model_source, config, self.device.clone())
+            .build(model_source, config)
             .map_err(|message| FleetManagedInferenceError::FactoryFailed {
                 name: self.inference_name.clone(),
                 message,

--- a/crates/burn-central-fleet/src/inference.rs
+++ b/crates/burn-central-fleet/src/inference.rs
@@ -2,7 +2,7 @@ use std::sync::{Arc, Mutex, RwLock};
 use std::time::{Duration, Instant};
 
 use arc_swap::ArcSwapOption;
-use burn::prelude::Backend;
+use burn::tensor::Device;
 use burn_central_artifact::bundle::FsBundle;
 use burn_central_inference::{Inference, InferenceWriter};
 
@@ -15,25 +15,24 @@ pub enum FleetManagedInferenceError {
     FactoryFailed { name: String, message: String },
 }
 
-pub trait FleetManagedFactory<B: Backend, I>: Send + Sync {
+pub trait FleetManagedFactory<I>: Send + Sync {
     fn build(
         &self,
         model_source: FsBundle,
         runtime_config: serde_json::Value,
-        device: B::Device,
+        device: Device,
     ) -> Result<I, String>;
 }
 
-impl<F, B, I> FleetManagedFactory<B, I> for F
+impl<F, I> FleetManagedFactory<I> for F
 where
-    F: Fn(FsBundle, serde_json::Value, B::Device) -> Result<I, String> + Send + Sync,
-    B: Backend,
+    F: Fn(FsBundle, serde_json::Value, Device) -> Result<I, String> + Send + Sync,
 {
     fn build(
         &self,
         model_source: FsBundle,
         runtime_config: serde_json::Value,
-        device: B::Device,
+        device: Device,
     ) -> Result<I, String> {
         self(model_source, runtime_config, device)
     }
@@ -45,27 +44,26 @@ struct ActiveInference<I> {
 }
 
 /// Inference wrapper that bootstraps burn-central features like fleet registration and telemetry on top of a typed inference implementation.
-pub struct FleetManagedInference<B: Backend, I> {
+pub struct FleetManagedInference<I> {
     inference_name: String,
     fleet_session: RwLock<FleetDeviceSession>,
-    factory: Box<dyn FleetManagedFactory<B, I>>,
-    device: B::Device,
+    factory: Box<dyn FleetManagedFactory<I>>,
+    device: Device,
     active: ArcSwapOption<ActiveInference<I>>,
     reconcile_gate: Mutex<()>,
     last_sync_at: Mutex<Option<Instant>>,
     sync_interval: Duration,
 }
 
-impl<B, I> FleetManagedInference<B, I>
+impl<I> FleetManagedInference<I>
 where
-    B: Backend,
     I: Inference,
 {
     pub fn init(
         inference_name: impl Into<String>,
         fleet_session: FleetDeviceSession,
-        factory: Box<dyn FleetManagedFactory<B, I>>,
-        device: B::Device,
+        factory: Box<dyn FleetManagedFactory<I>>,
+        device: Device,
     ) -> Result<Self, FleetManagedInferenceError> {
         let inference = Self {
             inference_name: inference_name.into(),
@@ -200,9 +198,8 @@ where
     }
 }
 
-impl<B, I> Inference for FleetManagedInference<B, I>
+impl<I> Inference for FleetManagedInference<I>
 where
-    B: Backend,
     I: Inference,
 {
     type Input = <I as Inference>::Input;

--- a/crates/burn-central-macros/src/lib.rs
+++ b/crates/burn-central-macros/src/lib.rs
@@ -210,8 +210,8 @@ pub fn register(args: TokenStream, item: TokenStream) -> TokenStream {
         ProcedureType::Training => {
             quote! {
                 #[doc(hidden)]
-                pub fn #builder_fn_name<B: burn::tensor::backend::AutodiffBackend>(
-                    exec: &mut burn_central::runtime::ExecutorBuilder<B>,
+                pub fn #builder_fn_name(
+                    exec: &mut burn_central::runtime::ExecutorBuilder,
                 ) {
                     exec.train(#registered_name_str, #fn_name);
                 }
@@ -220,8 +220,8 @@ pub fn register(args: TokenStream, item: TokenStream) -> TokenStream {
         ProcedureType::Inference => {
             quote! {
                 #[doc(hidden)]
-                pub fn #builder_fn_name<B: burn::prelude::Backend>(
-                    reg: &mut burn_central::runtime::inference::InferenceRegistry<B>,
+                pub fn #builder_fn_name(
+                    reg: &mut burn_central::runtime::inference::InferenceRegistry,
                 ) {
                     reg.infer(#registered_name_str, #fn_name);
                 }

--- a/crates/burn-central-runtime/Cargo.toml
+++ b/crates/burn-central-runtime/Cargo.toml
@@ -19,7 +19,6 @@ burn-central-inference.workspace = true
 burn-central-artifact.workspace = true
 burn-central-experiment.workspace = true
 burn-central-client.workspace = true
-burn.workspace = true
 thiserror.workspace = true
 variadics_please.workspace = true
 syn.workspace = true

--- a/crates/burn-central-runtime/src/executor.rs
+++ b/crates/burn-central-runtime/src/executor.rs
@@ -174,7 +174,7 @@ impl Executor {
         self.handlers.keys().cloned().collect()
     }
 
-    /// Runs a routine for the specified target with the given devices and arguments override.
+    /// Runs a routine for the specified target with the given arguments override.
     pub fn run(
         &self,
         kind: ActionKind,

--- a/crates/burn-central-runtime/src/executor.rs
+++ b/crates/burn-central-runtime/src/executor.rs
@@ -3,7 +3,6 @@ use crate::output::{ExperimentOutput, TrainOutput};
 use crate::params::args::{LaunchArgs, deserialize_and_merge_with_default};
 use crate::routine::{BoxedRoutine, ExecutorRoutineWrapper, IntoRoutine, Routine};
 use anyhow::Result;
-use burn::tensor::Device;
 use burn_central_experiment::integration::tracing::try_init_tracing_subscriber;
 use burn_central_experiment::{CancelToken, ExperimentRun, ExperimentRunHandleExt};
 use std::collections::HashMap;
@@ -16,7 +15,6 @@ pub struct ExecutionContext {
     namespace: String,
     project: String,
     args_override: Option<serde_json::Value>,
-    devices: Vec<Device>,
     experiment: Option<ExperimentRun>,
     cancel_token: CancelToken,
 }
@@ -47,10 +45,6 @@ impl ExecutionContext {
 
     pub fn cancel_token(&self) -> &CancelToken {
         &self.cancel_token
-    }
-
-    pub fn devices(&self) -> &[Device] {
-        &self.devices
     }
 
     pub fn client(&self) -> Option<&burn_central_client::Client> {
@@ -185,7 +179,6 @@ impl Executor {
         &self,
         kind: ActionKind,
         name: impl AsRef<str>,
-        devices: impl IntoIterator<Item = Device>,
         args_override: Option<String>,
     ) -> Result<(), RuntimeError> {
         let routine = name.as_ref();
@@ -224,7 +217,6 @@ impl Executor {
             namespace: self.namespace.clone().unwrap_or_default(),
             project: self.project.clone().unwrap_or_default(),
             args_override,
-            devices: devices.into_iter().collect(),
             experiment: None,
             cancel_token: CancelToken::new(),
         };
@@ -304,12 +296,10 @@ impl Executor {
 mod test {
     use std::convert::Infallible;
 
+    use crate::Model;
     use crate::params::args::Args;
-    use crate::{Model, MultiDevice};
 
     use super::*;
-    use burn::nn::{Linear, LinearConfig};
-    use burn::prelude::*;
     use burn_central_artifact::bundle::{BundleEncode, BundleSink};
     use serde::{Deserialize, Serialize};
 
@@ -319,12 +309,8 @@ mod test {
         }
     }
 
-    type TestDevice = Device;
-
-    #[derive(Module, Debug)]
-    struct TestModel {
-        linear: Linear,
-    }
+    #[derive(Debug)]
+    struct TestModel;
 
     impl BundleEncode for TestModel {
         type Settings = ();
@@ -338,13 +324,6 @@ mod test {
         }
     }
 
-    impl TestModel {
-        fn new(device: &Device) -> Self {
-            let linear = LinearConfig::new(10, 5).init(device);
-            TestModel { linear }
-        }
-    }
-
     #[derive(Serialize, Deserialize, Debug, Default, Clone)]
     struct TestArgs {
         lr: f32,
@@ -354,17 +333,12 @@ mod test {
     // --- Test Routines ---
 
     fn simple_train_step() -> Result<Model<TestModel>, String> {
-        let device = Device::default();
-        let model = TestModel::new(&device);
+        let model = TestModel;
         Ok(model.into())
     }
 
-    fn train_with_params(
-        args: Args<TestArgs>,
-        devices: MultiDevice,
-        cancel: CancelToken,
-    ) -> Model<TestModel> {
-        let model = TestModel::new(&devices[0]);
+    fn train_with_params(args: Args<TestArgs>, cancel: CancelToken) -> Model<TestModel> {
+        let model = TestModel;
         assert_eq!(args.lr, 0.01);
         assert_eq!(args.epochs, 10);
         println!("Cancel token available: {}", cancel.is_cancelled());
@@ -384,12 +358,7 @@ mod test {
         builder.train("simple_task", simple_train_step);
         let executor = builder.build_offline();
 
-        let result = executor.run(
-            "train".parse().unwrap(),
-            "simple_task",
-            [TestDevice::default()],
-            None,
-        );
+        let result = executor.run("train".parse().unwrap(), "simple_task", None);
         assert!(result.is_ok());
     }
 
@@ -401,12 +370,7 @@ mod test {
 
         let args_json = r#"{"lr": 0.01, "epochs": 10}"#.to_string();
 
-        let result = executor.run(
-            "train".parse().unwrap(),
-            "complex_task",
-            [TestDevice::default()],
-            Some(args_json),
-        );
+        let result = executor.run("train".parse().unwrap(), "complex_task", Some(args_json));
         assert!(result.is_ok());
     }
 
@@ -415,12 +379,7 @@ mod test {
         let builder = Executor::builder();
         let executor = builder.build_offline();
 
-        let result = executor.run(
-            "train".parse().unwrap(),
-            "non_existent_task",
-            [TestDevice::default()],
-            None,
-        );
+        let result = executor.run("train".parse().unwrap(), "non_existent_task", None);
 
         assert!(matches!(result, Err(RuntimeError::HandlerNotFound(_))));
     }
@@ -431,12 +390,7 @@ mod test {
         builder.train("failing_task", failing_routine);
         let executor = builder.build_offline();
 
-        let result = executor.run(
-            "train".parse().unwrap(),
-            "failing_task",
-            [TestDevice::default()],
-            None,
-        );
+        let result = executor.run("train".parse().unwrap(), "failing_task", None);
 
         assert!(matches!(result, Err(RuntimeError::HandlerFailed(_))));
     }
@@ -448,8 +402,8 @@ mod test {
         builder.train("task2", ("custom_name_2", simple_train_step));
         let executor = builder.build_offline();
 
-        let res1 = executor.run("train".parse().unwrap(), "task1", [], None);
-        let res2 = executor.run("train".parse().unwrap(), "task2", [], None);
+        let res1 = executor.run("train".parse().unwrap(), "task1", None);
+        let res2 = executor.run("train".parse().unwrap(), "task2", None);
 
         assert!(res1.is_ok());
         assert!(res2.is_ok());

--- a/crates/burn-central-runtime/src/executor.rs
+++ b/crates/burn-central-runtime/src/executor.rs
@@ -1,29 +1,27 @@
-use anyhow::Result;
-use burn::prelude::Backend;
-use burn::tensor::backend::AutodiffBackend;
-
 use crate::error::RuntimeError;
 use crate::output::{ExperimentOutput, TrainOutput};
 use crate::params::args::{LaunchArgs, deserialize_and_merge_with_default};
 use crate::routine::{BoxedRoutine, ExecutorRoutineWrapper, IntoRoutine, Routine};
+use anyhow::Result;
+use burn::tensor::Device;
 use burn_central_experiment::integration::tracing::try_init_tracing_subscriber;
 use burn_central_experiment::{CancelToken, ExperimentRun, ExperimentRunHandleExt};
 use std::collections::HashMap;
 
-type ExecutorRoutine<B> = BoxedRoutine<ExecutionContext<B>, (), ()>;
+type ExecutorRoutine = BoxedRoutine<ExecutionContext, (), ()>;
 
 /// The execution context for a routine, containing the necessary information to run it.
-pub struct ExecutionContext<B: Backend> {
+pub struct ExecutionContext {
     client: Option<burn_central_client::Client>,
     namespace: String,
     project: String,
     args_override: Option<serde_json::Value>,
-    devices: Vec<B::Device>,
+    devices: Vec<Device>,
     experiment: Option<ExperimentRun>,
     cancel_token: CancelToken,
 }
 
-impl<B: Backend> ExecutionContext<B> {
+impl ExecutionContext {
     /// Retrieve args merged on top of `A::default()`.
     ///
     /// This powers the `Args<A>` routine extractor for training routines.
@@ -51,7 +49,7 @@ impl<B: Backend> ExecutionContext<B> {
         &self.cancel_token
     }
 
-    pub fn devices(&self) -> &[B::Device] {
+    pub fn devices(&self) -> &[Device] {
         &self.devices
     }
 
@@ -96,11 +94,11 @@ impl std::fmt::Display for TargetId {
 // Hide element that are only used internally by the gen crate.
 #[doc(hidden)]
 /// A builder for creating an `Executor` instance with registered routines.
-pub struct ExecutorBuilder<B: AutodiffBackend> {
-    executor: Executor<B>,
+pub struct ExecutorBuilder {
+    executor: Executor,
 }
 
-impl<B: AutodiffBackend> ExecutorBuilder<B> {
+impl ExecutorBuilder {
     fn new() -> Self {
         Self {
             executor: Executor {
@@ -113,11 +111,11 @@ impl<B: AutodiffBackend> ExecutorBuilder<B> {
         }
     }
 
-    fn register<M, O: ExperimentOutput<B>>(
+    fn register<M, O: ExperimentOutput>(
         &mut self,
         kind: ActionKind,
         name: impl Into<String>,
-        handler: impl IntoRoutine<ExecutionContext<B>, (), O, M>,
+        handler: impl IntoRoutine<ExecutionContext, (), O, M>,
     ) -> &mut Self {
         let wrapper = ExecutorRoutineWrapper::new(IntoRoutine::into_routine(handler));
         let routine = Box::new(wrapper);
@@ -134,10 +132,10 @@ impl<B: AutodiffBackend> ExecutorBuilder<B> {
         self
     }
 
-    pub fn train<M, O: TrainOutput<B>>(
+    pub fn train<M, O: TrainOutput>(
         &mut self,
         name: impl Into<String>,
-        handler: impl IntoRoutine<ExecutionContext<B>, (), O, M>,
+        handler: impl IntoRoutine<ExecutionContext, (), O, M>,
     ) -> &mut Self {
         self.register(ActionKind::Train, name, handler);
         self
@@ -149,7 +147,7 @@ impl<B: AutodiffBackend> ExecutorBuilder<B> {
         env: burn_central_client::Env,
         namespace: impl Into<String>,
         project: impl Into<String>,
-    ) -> Executor<B> {
+    ) -> Executor {
         let mut executor = self.executor;
         executor.credentials = Some(credentials.into());
         executor.env = Some(env);
@@ -163,17 +161,17 @@ impl<B: AutodiffBackend> ExecutorBuilder<B> {
 // Hide element that are only used internally by the gen crate.
 #[doc(hidden)]
 /// An executor that manages the execution of routines for different targets.
-pub struct Executor<B: Backend> {
+pub struct Executor {
     credentials: Option<burn_central_client::BurnCentralCredentials>,
     env: Option<burn_central_client::Env>,
     namespace: Option<String>,
     project: Option<String>,
-    handlers: HashMap<TargetId, ExecutorRoutine<B>>,
+    handlers: HashMap<TargetId, ExecutorRoutine>,
 }
 
-impl<B: AutodiffBackend> Executor<B> {
+impl Executor {
     /// Creates a new `ExecutorBuilder` to configure and build an `Executor`.
-    pub fn builder() -> ExecutorBuilder<B> {
+    pub fn builder() -> ExecutorBuilder {
         ExecutorBuilder::new()
     }
 
@@ -187,7 +185,7 @@ impl<B: AutodiffBackend> Executor<B> {
         &self,
         kind: ActionKind,
         name: impl AsRef<str>,
-        devices: impl IntoIterator<Item = B::Device>,
+        devices: impl IntoIterator<Item = Device>,
         args_override: Option<String>,
     ) -> Result<(), RuntimeError> {
         let routine = name.as_ref();
@@ -310,29 +308,25 @@ mod test {
     use crate::{Model, MultiDevice};
 
     use super::*;
-    use burn::backend::{Autodiff, NdArray};
     use burn::nn::{Linear, LinearConfig};
     use burn::prelude::*;
-    use burn::tensor::backend::BackendTypes;
     use burn_central_artifact::bundle::{BundleEncode, BundleSink};
     use serde::{Deserialize, Serialize};
 
-    impl<B: AutodiffBackend> ExecutorBuilder<B> {
-        pub fn build_offline(self) -> Executor<B> {
+    impl ExecutorBuilder {
+        pub fn build_offline(self) -> Executor {
             self.executor
         }
     }
 
-    // A backend stub for testing purposes.
-    type TestBackend = Autodiff<NdArray<f32>>;
-    type TestDevice = <NdArray<f32> as BackendTypes>::Device;
+    type TestDevice = Device;
 
     #[derive(Module, Debug)]
-    struct TestModel<B: Backend> {
-        linear: Linear<B>,
+    struct TestModel {
+        linear: Linear,
     }
 
-    impl<B: Backend> BundleEncode for TestModel<B> {
+    impl BundleEncode for TestModel {
         type Settings = ();
         type Error = Infallible;
         fn encode<E: BundleSink>(
@@ -344,8 +338,8 @@ mod test {
         }
     }
 
-    impl<B: AutodiffBackend> TestModel<B> {
-        fn new(device: &B::Device) -> Self {
+    impl TestModel {
+        fn new(device: &Device) -> Self {
             let linear = LinearConfig::new(10, 5).init(device);
             TestModel { linear }
         }
@@ -359,17 +353,17 @@ mod test {
 
     // --- Test Routines ---
 
-    fn simple_train_step<B: AutodiffBackend>() -> Result<Model<TestModel<B>>, String> {
-        let device = B::Device::default();
+    fn simple_train_step() -> Result<Model<TestModel>, String> {
+        let device = Device::default();
         let model = TestModel::new(&device);
         Ok(model.into())
     }
 
-    fn train_with_params<B: AutodiffBackend>(
+    fn train_with_params(
         args: Args<TestArgs>,
-        devices: MultiDevice<B>,
+        devices: MultiDevice,
         cancel: CancelToken,
-    ) -> Model<TestModel<B>> {
+    ) -> Model<TestModel> {
         let model = TestModel::new(&devices[0]);
         assert_eq!(args.lr, 0.01);
         assert_eq!(args.epochs, 10);
@@ -378,7 +372,7 @@ mod test {
         model.into()
     }
 
-    fn failing_routine<B: AutodiffBackend>() -> Result<Model<TestModel<B>>> {
+    fn failing_routine() -> Result<Model<TestModel>> {
         anyhow::bail!("Failing routine");
     }
 
@@ -386,8 +380,8 @@ mod test {
 
     #[test]
     fn should_run_simple_routine_successfully() {
-        let mut builder = Executor::<TestBackend>::builder();
-        builder.train("simple_task", simple_train_step::<TestBackend>);
+        let mut builder = Executor::builder();
+        builder.train("simple_task", simple_train_step);
         let executor = builder.build_offline();
 
         let result = executor.run(
@@ -401,7 +395,7 @@ mod test {
 
     #[test]
     fn should_inject_parameters_and_handle_output() {
-        let mut builder = Executor::<TestBackend>::builder();
+        let mut builder = Executor::builder();
         builder.train("complex_task", train_with_params);
         let executor = builder.build_offline();
 
@@ -418,7 +412,7 @@ mod test {
 
     #[test]
     fn should_return_handler_not_found_error() {
-        let builder = Executor::<TestBackend>::builder();
+        let builder = Executor::builder();
         let executor = builder.build_offline();
 
         let result = executor.run(
@@ -433,8 +427,8 @@ mod test {
 
     #[test]
     fn should_handle_failing_routine() {
-        let mut builder = Executor::<TestBackend>::builder();
-        builder.train("failing_task", failing_routine::<TestBackend>);
+        let mut builder = Executor::builder();
+        builder.train("failing_task", failing_routine);
         let executor = builder.build_offline();
 
         let result = executor.run(
@@ -449,12 +443,9 @@ mod test {
 
     #[test]
     fn should_support_named_routines() {
-        let mut builder = Executor::<TestBackend>::builder();
-        builder.train(
-            "task1",
-            simple_train_step::<TestBackend>.with_name("custom_name_1"),
-        );
-        builder.train("task2", ("custom_name_2", simple_train_step::<TestBackend>));
+        let mut builder = Executor::builder();
+        builder.train("task1", simple_train_step.with_name("custom_name_1"));
+        builder.train("task2", ("custom_name_2", simple_train_step));
         let executor = builder.build_offline();
 
         let res1 = executor.run("train".parse().unwrap(), "task1", [], None);

--- a/crates/burn-central-runtime/src/inference/fleet.rs
+++ b/crates/burn-central-runtime/src/inference/fleet.rs
@@ -1,4 +1,3 @@
-use burn::tensor::Device;
 use burn_central_client::Env;
 use burn_central_fleet::{
     FleetDeviceSession, FleetManagedFactory, FleetManagedInference, FleetRegistrationToken,
@@ -19,7 +18,6 @@ pub fn build_fleet_managed_inference<I, M, R>(
     factory: impl IntoRoutine<InferenceContext, (), I, M>,
     token: impl Into<FleetRegistrationToken>,
     metadata: impl Serialize,
-    device: Device,
 ) -> Result<FleetManagedInference<I::Inference>, InferenceError>
 where
     I: InferenceFactoryReturn<R>,
@@ -36,11 +34,10 @@ where
     let inference_name = routine.name().to_string();
     let error_name = inference_name.clone();
 
-    let inference_factory: Box<dyn FleetManagedFactory<I::Inference>> = Box::new(
-        move |model_source, runtime_config: serde_json::Value, device: Device| {
+    let inference_factory: Box<dyn FleetManagedFactory<I::Inference>> =
+        Box::new(move |model_source, runtime_config: serde_json::Value| {
             let init = InferenceInit {
                 model: Some(ModelSource::from(model_source)).into(),
-                device,
             };
             let mut ctx = InferenceContext::new(init, InferenceArgs::new(Some(runtime_config)));
 
@@ -51,8 +48,7 @@ where
             factory_output.into_inference().map_err(|message| {
                 format!("inference handler '{error_name}' failed to initialize: {message}")
             })
-        },
-    );
+        });
 
     let metadata = serde_json::json!({
         "name": inference_name,
@@ -66,16 +62,12 @@ where
             message: e.to_string(),
         })?;
 
-    let inference = FleetManagedInference::init(
-        inference_name.clone(),
-        fleet_session,
-        inference_factory,
-        device,
-    )
-    .map_err(|e| InferenceError::FactoryFailed {
-        name: inference_name,
-        message: e.to_string(),
-    })?;
+    let inference =
+        FleetManagedInference::init(inference_name.clone(), fleet_session, inference_factory)
+            .map_err(|e| InferenceError::FactoryFailed {
+                name: inference_name,
+                message: e.to_string(),
+            })?;
 
     Ok(inference)
 }

--- a/crates/burn-central-runtime/src/inference/fleet.rs
+++ b/crates/burn-central-runtime/src/inference/fleet.rs
@@ -1,4 +1,4 @@
-use burn::prelude::Backend;
+use burn::tensor::Device;
 use burn_central_client::Env;
 use burn_central_fleet::{
     FleetDeviceSession, FleetManagedFactory, FleetManagedInference, FleetRegistrationToken,
@@ -15,14 +15,13 @@ use crate::{
 };
 
 /// Build a typed inference instance directly from a factory routine.
-pub fn build_fleet_managed_inference<B, I, M, R>(
-    factory: impl IntoRoutine<InferenceContext<B>, (), I, M>,
+pub fn build_fleet_managed_inference<I, M, R>(
+    factory: impl IntoRoutine<InferenceContext, (), I, M>,
     token: impl Into<FleetRegistrationToken>,
     metadata: impl Serialize,
-    device: B::Device,
-) -> Result<FleetManagedInference<B, I::Inference>, InferenceError>
+    device: Device,
+) -> Result<FleetManagedInference<I::Inference>, InferenceError>
 where
-    B: Backend,
     I: InferenceFactoryReturn<R>,
     I::Inference: Inference + Send + Sync + 'static,
     M: 'static,
@@ -37,8 +36,8 @@ where
     let inference_name = routine.name().to_string();
     let error_name = inference_name.clone();
 
-    let inference_factory: Box<dyn FleetManagedFactory<B, I::Inference>> = Box::new(
-        move |model_source, runtime_config: serde_json::Value, device: B::Device| {
+    let inference_factory: Box<dyn FleetManagedFactory<I::Inference>> = Box::new(
+        move |model_source, runtime_config: serde_json::Value, device: Device| {
             let init = InferenceInit {
                 model: Some(ModelSource::from(model_source)).into(),
                 device,

--- a/crates/burn-central-runtime/src/inference/registry.rs
+++ b/crates/burn-central-runtime/src/inference/registry.rs
@@ -1,8 +1,7 @@
+use crate::Args;
 use crate::params::RoutineParam;
 use crate::params::args::{LaunchArgs, deserialize_and_merge_with_default};
 use crate::routine::{BoxedRoutine, IntoRoutine};
-use crate::{Args, MultiDevice};
-use burn::tensor::Device;
 use burn_central_artifact::bundle::{BundleDecode, FsBundle};
 use burn_central_inference::{ErasedInference, Inference, JsonInference};
 use derive_more::{Deref, From};
@@ -35,7 +34,6 @@ impl ModelSource {
 
 pub struct InferenceInit {
     pub model: RefCell<Option<ModelSource>>,
-    pub device: Device,
 }
 
 /// Optional inference arguments passed at model-build time.
@@ -104,10 +102,6 @@ impl InferenceContext {
             .take()
             .expect("model source should be set in inference context")
     }
-
-    pub fn device(&self) -> &Device {
-        &self.init.device
-    }
 }
 
 impl RoutineParam<InferenceContext> for ModelSource {
@@ -115,14 +109,6 @@ impl RoutineParam<InferenceContext> for ModelSource {
 
     fn try_retrieve(ctx: &InferenceContext) -> anyhow::Result<Self::Item<'_>> {
         Ok(ctx.model())
-    }
-}
-
-impl RoutineParam<InferenceContext> for MultiDevice {
-    type Item<'new> = MultiDevice;
-
-    fn try_retrieve(ctx: &InferenceContext) -> anyhow::Result<Self::Item<'_>> {
-        Ok(MultiDevice(vec![ctx.device().clone()]))
     }
 }
 

--- a/crates/burn-central-runtime/src/inference/registry.rs
+++ b/crates/burn-central-runtime/src/inference/registry.rs
@@ -2,7 +2,7 @@ use crate::params::RoutineParam;
 use crate::params::args::{LaunchArgs, deserialize_and_merge_with_default};
 use crate::routine::{BoxedRoutine, IntoRoutine};
 use crate::{Args, MultiDevice};
-use burn::prelude::Backend;
+use burn::tensor::Device;
 use burn_central_artifact::bundle::{BundleDecode, FsBundle};
 use burn_central_inference::{ErasedInference, Inference, JsonInference};
 use derive_more::{Deref, From};
@@ -33,9 +33,9 @@ impl ModelSource {
     }
 }
 
-pub struct InferenceInit<B: Backend> {
+pub struct InferenceInit {
     pub model: RefCell<Option<ModelSource>>,
-    pub device: B::Device,
+    pub device: Device,
 }
 
 /// Optional inference arguments passed at model-build time.
@@ -78,13 +78,13 @@ where
 }
 
 /// The execution context for inference initialization routines.
-pub struct InferenceContext<B: Backend> {
-    init: InferenceInit<B>,
+pub struct InferenceContext {
+    init: InferenceInit,
     args: InferenceArgs,
 }
 
-impl<B: Backend> InferenceContext<B> {
-    pub fn new(init: InferenceInit<B>, args: impl Into<InferenceArgs>) -> Self {
+impl InferenceContext {
+    pub fn new(init: InferenceInit, args: impl Into<InferenceArgs>) -> Self {
         Self {
             init,
             args: args.into(),
@@ -105,40 +105,40 @@ impl<B: Backend> InferenceContext<B> {
             .expect("model source should be set in inference context")
     }
 
-    pub fn device(&self) -> &B::Device {
+    pub fn device(&self) -> &Device {
         &self.init.device
     }
 }
 
-impl<B: Backend> RoutineParam<InferenceContext<B>> for ModelSource {
+impl RoutineParam<InferenceContext> for ModelSource {
     type Item<'new> = ModelSource;
 
-    fn try_retrieve(ctx: &InferenceContext<B>) -> anyhow::Result<Self::Item<'_>> {
+    fn try_retrieve(ctx: &InferenceContext) -> anyhow::Result<Self::Item<'_>> {
         Ok(ctx.model())
     }
 }
 
-impl<B: Backend> RoutineParam<InferenceContext<B>> for MultiDevice<B> {
-    type Item<'new> = MultiDevice<B>;
+impl RoutineParam<InferenceContext> for MultiDevice {
+    type Item<'new> = MultiDevice;
 
-    fn try_retrieve(ctx: &InferenceContext<B>) -> anyhow::Result<Self::Item<'_>> {
+    fn try_retrieve(ctx: &InferenceContext) -> anyhow::Result<Self::Item<'_>> {
         Ok(MultiDevice(vec![ctx.device().clone()]))
     }
 }
 
-impl<B: Backend, C: LaunchArgs> RoutineParam<InferenceContext<B>> for Args<C> {
+impl<C: LaunchArgs> RoutineParam<InferenceContext> for Args<C> {
     type Item<'new> = Args<C>;
 
-    fn try_retrieve(ctx: &InferenceContext<B>) -> anyhow::Result<Self::Item<'_>> {
+    fn try_retrieve(ctx: &InferenceContext) -> anyhow::Result<Self::Item<'_>> {
         let cfg = ctx.use_merged_args();
         Ok(Args(cfg))
     }
 }
 
-type InferenceRoutine<B, I> = BoxedRoutine<InferenceContext<B>, (), I>;
+type InferenceRoutine<I> = BoxedRoutine<InferenceContext, (), I>;
 
-trait ErasedFactory<B: Backend>: Send + Sync {
-    fn build(&self, ctx: InferenceContext<B>) -> Result<Box<dyn ErasedInference>, InferenceError>;
+trait ErasedFactory: Send + Sync {
+    fn build(&self, ctx: InferenceContext) -> Result<Box<dyn ErasedInference>, InferenceError>;
 }
 
 pub trait InferenceFactoryReturn<M>: Send + 'static {
@@ -172,24 +172,20 @@ where
     }
 }
 
-struct RoutineFactory<B: Backend, I, R> {
+struct RoutineFactory<I, R> {
     name: String,
-    routine: InferenceRoutine<B, I>,
+    routine: InferenceRoutine<I>,
     _types: PhantomData<fn(I) -> R>,
 }
 
-impl<B, I, R> ErasedFactory<B> for RoutineFactory<B, I, R>
+impl<I, R> ErasedFactory for RoutineFactory<I, R>
 where
-    B: Backend,
     I: InferenceFactoryReturn<R>,
     I::Inference: Inference + Send + Sync + 'static,
     <I::Inference as Inference>::Input: DeserializeOwned + Send + Sync + 'static,
     <I::Inference as Inference>::Output: Serialize + Send + Sync + 'static,
 {
-    fn build(
-        &self,
-        mut ctx: InferenceContext<B>,
-    ) -> Result<Box<dyn ErasedInference>, InferenceError> {
+    fn build(&self, mut ctx: InferenceContext) -> Result<Box<dyn ErasedInference>, InferenceError> {
         let factory_output =
             self.routine
                 .run((), &mut ctx)
@@ -210,17 +206,17 @@ where
 }
 
 /// Registry of inference factories keyed by name.
-pub struct InferenceRegistry<B: Backend> {
-    factories: HashMap<String, Box<dyn ErasedFactory<B>>>,
+pub struct InferenceRegistry {
+    factories: HashMap<String, Box<dyn ErasedFactory>>,
 }
 
-impl<B: Backend> Default for InferenceRegistry<B> {
+impl Default for InferenceRegistry {
     fn default() -> Self {
         Self::new()
     }
 }
 
-impl<B: Backend> InferenceRegistry<B> {
+impl InferenceRegistry {
     pub fn new() -> Self {
         Self {
             factories: HashMap::new(),
@@ -233,7 +229,7 @@ impl<B: Backend> InferenceRegistry<B> {
         I::Inference: Inference + Send + Sync + 'static,
         <I::Inference as Inference>::Input: DeserializeOwned + Send + Sync + 'static,
         <I::Inference as Inference>::Output: Serialize + Send + Sync + 'static,
-        S: IntoRoutine<InferenceContext<B>, (), I, M> + 'static,
+        S: IntoRoutine<InferenceContext, (), I, M> + 'static,
         M: 'static,
         R: 'static,
     {
@@ -252,7 +248,7 @@ impl<B: Backend> InferenceRegistry<B> {
     pub fn build_inference(
         &self,
         name: impl AsRef<str>,
-        init: InferenceInit<B>,
+        init: InferenceInit,
         args: Option<impl Into<InferenceArgs>>,
     ) -> Result<Box<dyn ErasedInference>, InferenceError> {
         let factory = self

--- a/crates/burn-central-runtime/src/lib.rs
+++ b/crates/burn-central-runtime/src/lib.rs
@@ -33,5 +33,5 @@ pub use executor::{Executor, ExecutorBuilder};
 pub use params::{
     args::{Args, LaunchArgs},
     artifact_loader::ArtifactLoader,
-    default::{Model, MultiDevice},
+    default::Model,
 };

--- a/crates/burn-central-runtime/src/lib.rs
+++ b/crates/burn-central-runtime/src/lib.rs
@@ -33,5 +33,5 @@ pub use executor::{Executor, ExecutorBuilder};
 pub use params::{
     args::{Args, LaunchArgs},
     artifact_loader::ArtifactLoader,
-    default::Model,
+    default::{Model, MultiDevice},
 };

--- a/crates/burn-central-runtime/src/output.rs
+++ b/crates/burn-central-runtime/src/output.rs
@@ -1,6 +1,5 @@
 use crate::executor::ExecutionContext;
 use crate::params::default::Model;
-use burn::prelude::Backend;
 use burn_central_artifact::bundle::BundleEncode;
 use burn_central_experiment::ArtifactKind;
 use std::fmt::Display;
@@ -12,14 +11,14 @@ pub trait RoutineOutput<Ctx>: Sized + Send + 'static {
     fn apply_output(self, ctx: &mut Ctx) -> anyhow::Result<()>;
 }
 
-pub trait ExperimentOutput<B: Backend>: RoutineOutput<ExecutionContext<B>> {}
+pub trait ExperimentOutput: RoutineOutput<ExecutionContext> {}
 
 /// This trait is a marker for outputs that are specifically related to training routines.
-pub trait TrainOutput<B: Backend>: ExperimentOutput<B> {}
+pub trait TrainOutput: ExperimentOutput {}
 
 /// This implementation is for the case where the output is simply `()`, meaning no output to apply.
-impl<B: Backend> RoutineOutput<ExecutionContext<B>> for () {
-    fn apply_output(self, _ctx: &mut ExecutionContext<B>) -> anyhow::Result<()> {
+impl RoutineOutput<ExecutionContext> for () {
+    fn apply_output(self, _ctx: &mut ExecutionContext) -> anyhow::Result<()> {
         Ok(())
     }
 }
@@ -37,8 +36,8 @@ where
     }
 }
 
-impl<B: Backend, M: BundleEncode + Send + 'static> RoutineOutput<ExecutionContext<B>> for Model<M> {
-    fn apply_output(self, ctx: &mut ExecutionContext<B>) -> anyhow::Result<()> {
+impl<M: BundleEncode + Send + 'static> RoutineOutput<ExecutionContext> for Model<M> {
+    fn apply_output(self, ctx: &mut ExecutionContext) -> anyhow::Result<()> {
         if let Some(experiment) = ctx.experiment() {
             experiment.save_artifact("model", ArtifactKind::Model, self.0, &Default::default())?;
         }
@@ -46,25 +45,25 @@ impl<B: Backend, M: BundleEncode + Send + 'static> RoutineOutput<ExecutionContex
     }
 }
 
-impl<B: Backend, M: BundleEncode + Send + 'static> ExperimentOutput<B> for Model<M> {}
+impl<M: BundleEncode + Send + 'static> ExperimentOutput for Model<M> {}
 
-impl<B: Backend> ExperimentOutput<B> for () {}
+impl ExperimentOutput for () {}
 
 /// --- TrainOutput ---
-impl<B: Backend, M: BundleEncode + Send + 'static> TrainOutput<B> for Model<M> {}
+impl<M: BundleEncode + Send + 'static> TrainOutput for Model<M> {}
 
-impl<T, E, B: Backend> ExperimentOutput<B> for Result<T, E>
+impl<T, E> ExperimentOutput for Result<T, E>
 where
     E: 'static + Display + Send + Sync,
-    T: TrainOutput<B>,
+    T: TrainOutput,
 {
 }
 
-impl<T, E, B: Backend> TrainOutput<B> for Result<T, E>
+impl<T, E> TrainOutput for Result<T, E>
 where
-    T: TrainOutput<B>,
+    T: TrainOutput,
     E: Display + Send + Sync + 'static,
 {
 }
 
-impl<B: Backend> TrainOutput<B> for () {}
+impl TrainOutput for () {}

--- a/crates/burn-central-runtime/src/params/args.rs
+++ b/crates/burn-central-runtime/src/params/args.rs
@@ -1,4 +1,3 @@
-use burn::prelude::Backend;
 use derive_more::{Deref, From};
 use json_patch::merge;
 use serde::{Deserialize, Serialize};
@@ -35,10 +34,10 @@ pub fn deserialize_and_merge_with_default<T: LaunchArgs>(
 #[derive(From, Deref)]
 pub struct Args<T: LaunchArgs>(pub T);
 
-impl<B: Backend, C: LaunchArgs> RoutineParam<ExecutionContext<B>> for Args<C> {
+impl<C: LaunchArgs> RoutineParam<ExecutionContext> for Args<C> {
     type Item<'new> = Args<C>;
 
-    fn try_retrieve(ctx: &ExecutionContext<B>) -> anyhow::Result<Self::Item<'_>> {
+    fn try_retrieve(ctx: &ExecutionContext) -> anyhow::Result<Self::Item<'_>> {
         let cfg = ctx.use_merged_args();
         Ok(Args(cfg))
     }

--- a/crates/burn-central-runtime/src/params/artifact_loader.rs
+++ b/crates/burn-central-runtime/src/params/artifact_loader.rs
@@ -15,7 +15,6 @@ use burn_central_experiment::{ExperimentId, ExperimentRun, error::ExperimentErro
 /// # use burn_central_artifact::bundle::BundleDecode;
 /// # use burn_central::register;
 /// # use burn_central_runtime::Model;
-/// # use burn_central_runtime::MultiDevice;
 /// # use serde::*;
 /// #[derive(Deserialize, Serialize, Default)]
 /// pub struct LaunchArgs {
@@ -25,7 +24,6 @@ use burn_central_experiment::{ExperimentId, ExperimentRun, error::ExperimentErro
 /// #[register(training, name = "mnist")]
 /// pub fn training(
 ///     config: Args<LaunchArgs>,
-///     devices: MultiDevice,
 ///     loader: ArtifactLoader<MyModel>,
 /// ) -> Result<Model<MyModel>, String> {
 ///     // Load a pretrained model if an experiment number is provided.

--- a/crates/burn-central-runtime/src/params/artifact_loader.rs
+++ b/crates/burn-central-runtime/src/params/artifact_loader.rs
@@ -1,6 +1,5 @@
 use crate::executor::ExecutionContext;
 use crate::params::RoutineParam;
-use burn::prelude::Backend;
 use burn_central_artifact::bundle::BundleDecode;
 use burn_central_experiment::{ExperimentId, ExperimentRun, error::ExperimentError};
 
@@ -75,13 +74,13 @@ impl<'a, T: BundleDecode> ArtifactLoader<'a, T> {
     }
 }
 
-impl<B: Backend, T: BundleDecode> RoutineParam<ExecutionContext<B>> for ArtifactLoader<'_, T> {
+impl<T: BundleDecode> RoutineParam<ExecutionContext> for ArtifactLoader<'_, T> {
     type Item<'new>
         = ArtifactLoader<'new, T>
     where
-        ExecutionContext<B>: 'new;
+        ExecutionContext: 'new;
 
-    fn try_retrieve(ctx: &ExecutionContext<B>) -> anyhow::Result<Self::Item<'_>> {
+    fn try_retrieve(ctx: &ExecutionContext) -> anyhow::Result<Self::Item<'_>> {
         let experiment = ctx.experiment().ok_or_else(|| {
             anyhow::anyhow!("Burn Central client is not configured in the execution context")
         })?;

--- a/crates/burn-central-runtime/src/params/artifact_loader.rs
+++ b/crates/burn-central-runtime/src/params/artifact_loader.rs
@@ -23,11 +23,11 @@ use burn_central_experiment::{ExperimentId, ExperimentRun, error::ExperimentErro
 /// }
 ///
 /// #[register(training, name = "mnist")]
-/// pub fn training<B: AutodiffBackend>(
+/// pub fn training(
 ///     config: Args<LaunchArgs>,
-///     MultiDevice(devices): MultiDevice<B>,
-///     loader: ArtifactLoader<ModelArtifact<B>>,
-/// ) -> Result<Model<ModelArtifact<B::InnerBackend>>, String> {
+///     devices: MultiDevice,
+///     loader: ArtifactLoader<MyModel>,
+/// ) -> Result<Model<MyModel>, String> {
 ///     // Load a pretrained model if an experiment number is provided.
 ///     if let Some(experiment_num) = config.experiment_num {
 ///         let pretrained_model = loader

--- a/crates/burn-central-runtime/src/params/cancellation.rs
+++ b/crates/burn-central-runtime/src/params/cancellation.rs
@@ -1,12 +1,11 @@
-use burn::prelude::Backend;
 use burn_central_experiment::CancelToken;
 
 use crate::{executor::ExecutionContext, params::RoutineParam};
 
-impl<B: Backend> RoutineParam<ExecutionContext<B>> for CancelToken {
+impl RoutineParam<ExecutionContext> for CancelToken {
     type Item<'new> = CancelToken;
 
-    fn try_retrieve(ctx: &ExecutionContext<B>) -> anyhow::Result<Self::Item<'_>> {
+    fn try_retrieve(ctx: &ExecutionContext) -> anyhow::Result<Self::Item<'_>> {
         Ok(ctx.cancel_token().clone())
     }
 }

--- a/crates/burn-central-runtime/src/params/default.rs
+++ b/crates/burn-central-runtime/src/params/default.rs
@@ -1,18 +1,6 @@
 use crate::{executor::ExecutionContext, params::RoutineParam};
-use burn::tensor::Device;
 use burn_central_experiment::ExperimentRun;
 use derive_more::{Deref, From};
-
-/// Wrapper around multiple devices.
-///
-/// Since Burn Central CLI support selecting different backend on the fly. We handle the device
-/// selection in the generated crate. This structure is simply a marker for us to know where to
-/// inject the devices selected by the CLI.
-///
-/// We are planning to support multi device training in the future, however we currently only
-/// support one so this vector will always contains one device for now.
-#[derive(Clone, Debug, Deref, From)]
-pub struct MultiDevice(pub Vec<Device>);
 
 /// Wrapper around the model returned by a routine.
 ///
@@ -21,14 +9,6 @@ pub struct MultiDevice(pub Vec<Device>);
 /// artifact.
 #[derive(Clone, From, Deref)]
 pub struct Model<M>(pub M);
-
-impl RoutineParam<ExecutionContext> for MultiDevice {
-    type Item<'new> = MultiDevice;
-
-    fn try_retrieve(ctx: &ExecutionContext) -> anyhow::Result<Self::Item<'_>> {
-        Ok(MultiDevice(ctx.devices().into()))
-    }
-}
 
 impl RoutineParam<ExecutionContext> for &ExecutionContext {
     type Item<'new> = &'new ExecutionContext;

--- a/crates/burn-central-runtime/src/params/default.rs
+++ b/crates/burn-central-runtime/src/params/default.rs
@@ -1,5 +1,5 @@
 use crate::{executor::ExecutionContext, params::RoutineParam};
-use burn::prelude::Backend;
+use burn::tensor::Device;
 use burn_central_experiment::ExperimentRun;
 use derive_more::{Deref, From};
 
@@ -12,7 +12,7 @@ use derive_more::{Deref, From};
 /// We are planning to support multi device training in the future, however we currently only
 /// support one so this vector will always contains one device for now.
 #[derive(Clone, Debug, Deref, From)]
-pub struct MultiDevice<B: Backend>(pub Vec<B::Device>);
+pub struct MultiDevice(pub Vec<Device>);
 
 /// Wrapper around the model returned by a routine.
 ///
@@ -22,26 +22,26 @@ pub struct MultiDevice<B: Backend>(pub Vec<B::Device>);
 #[derive(Clone, From, Deref)]
 pub struct Model<M>(pub M);
 
-impl<B: Backend> RoutineParam<ExecutionContext<B>> for MultiDevice<B> {
-    type Item<'new> = MultiDevice<B>;
+impl RoutineParam<ExecutionContext> for MultiDevice {
+    type Item<'new> = MultiDevice;
 
-    fn try_retrieve(ctx: &ExecutionContext<B>) -> anyhow::Result<Self::Item<'_>> {
+    fn try_retrieve(ctx: &ExecutionContext) -> anyhow::Result<Self::Item<'_>> {
         Ok(MultiDevice(ctx.devices().into()))
     }
 }
 
-impl<B: Backend> RoutineParam<ExecutionContext<B>> for &ExecutionContext<B> {
-    type Item<'new> = &'new ExecutionContext<B>;
+impl RoutineParam<ExecutionContext> for &ExecutionContext {
+    type Item<'new> = &'new ExecutionContext;
 
-    fn try_retrieve(ctx: &ExecutionContext<B>) -> anyhow::Result<Self::Item<'_>> {
+    fn try_retrieve(ctx: &ExecutionContext) -> anyhow::Result<Self::Item<'_>> {
         Ok(ctx)
     }
 }
 
-impl<B: Backend> RoutineParam<ExecutionContext<B>> for &ExperimentRun {
+impl RoutineParam<ExecutionContext> for &ExperimentRun {
     type Item<'new> = &'new ExperimentRun;
 
-    fn try_retrieve(ctx: &ExecutionContext<B>) -> anyhow::Result<Self::Item<'_>> {
+    fn try_retrieve(ctx: &ExecutionContext) -> anyhow::Result<Self::Item<'_>> {
         ctx.experiment()
             .ok_or_else(|| anyhow::anyhow!("Experiment run not found"))
     }


### PR DESCRIPTION
- Remove the Backend and Device trait in the generated code to respect the contract of the new version of Burn
- Update documentation