### PR TITLE
Feat/experiment progress

### DIFF
--- a/crates/burn-central-experiment/src/lib.rs
+++ b/crates/burn-central-experiment/src/lib.rs
@@ -57,6 +57,7 @@ use serde::Serialize;
 mod cancellation;
 mod context;
 mod local;
+mod progress;
 mod reader;
 mod remote;
 mod session;

--- a/crates/burn-central-experiment/src/lib.rs
+++ b/crates/burn-central-experiment/src/lib.rs
@@ -69,12 +69,13 @@ pub use cancellation::{CancelToken, Cancellable};
 pub use context::{
     CurrentExperimentGuard, ExperimentGlobalExt, ExperimentInstrument, WithCurrentExperiment,
 };
-pub use session::ExperimentCompletion;
+pub use progress::{ProgressBuilder, ProgressGuard};
 
 use crate::error::{ExperimentError, ExperimentErrorKind};
 use crate::integration::tracing::registry::{TracingRegistration, TracingRegistry};
+use crate::progress::AtomicProgressIdAllocator;
 use crate::reader::ExperimentArtifactReader;
-use crate::session::{Event, ExperimentSession};
+use crate::session::{Event, ExperimentCompletion, ExperimentSession};
 
 /// Opaque identifier for an experiment run.
 ///
@@ -212,6 +213,7 @@ struct RunInner {
     state: Mutex<RunState>,
     session: Box<dyn ExperimentSession>,
     reader: Box<dyn ExperimentArtifactReader>,
+    progress_id_allocator: Arc<AtomicProgressIdAllocator>,
 }
 
 #[derive(Debug, Clone, Copy, PartialEq, Eq)]
@@ -241,6 +243,7 @@ impl ExperimentRun {
             state: Mutex::new(RunState::Active),
             session: Box::new(session),
             reader: Box::new(reader),
+            progress_id_allocator: Arc::new(AtomicProgressIdAllocator::new()),
         });
 
         let handle = ExperimentRunHandle {
@@ -424,6 +427,13 @@ impl ExperimentRun {
     ) -> Result<D, ExperimentError> {
         self.handle.use_artifact(experiment_id, name, settings)
     }
+
+    /// Create a progress builder for the run with the provided name.
+    ///
+    /// The returned builder can be used to start a progress node and receive a guard for updating and finishing it.
+    pub fn progress(&self, name: impl Into<String>) -> ProgressBuilder {
+        self.handle.progress(name)
+    }
 }
 
 /// Extension trait for cloning shareable handles from an [`ExperimentRun`].
@@ -596,6 +606,32 @@ impl ExperimentRunHandle {
                 e,
             )
         })
+    }
+
+    /// See [`ExperimentRun::progress`].
+    ///
+    /// If the originating run has already been finished or dropped, the progress builder will be a no-op.
+    pub fn progress(&self, name: impl Into<String>) -> ProgressBuilder {
+        let inner = match self.upgrade() {
+            Ok(inner) => inner,
+            Err(_) => {
+                return ProgressBuilder::new(
+                    Arc::new(|_| {}),
+                    Arc::new(AtomicProgressIdAllocator::new()),
+                    name.into(),
+                );
+            }
+        };
+        ProgressBuilder::new(
+            Arc::new({
+                let handle = self.clone();
+                move |e| {
+                    handle.record_event(Event::Progress(e)).ok();
+                }
+            }),
+            inner.progress_id_allocator.clone(),
+            name.into(),
+        )
     }
 }
 

--- a/crates/burn-central-experiment/src/lib.rs
+++ b/crates/burn-central-experiment/src/lib.rs
@@ -697,6 +697,7 @@ mod tests {
     use std::sync::atomic::{AtomicUsize, Ordering};
     use std::time::{SystemTime, UNIX_EPOCH};
 
+    use crate::progress::ProgressEvent;
     use crate::reader::{ExperimentReaderError, LoadedArtifact};
     use crate::session::BundleFn;
     use burn_central_artifact::bundle::{BundleSink, BundleSource};
@@ -820,6 +821,33 @@ mod tests {
             Event::Log { message } => assert_eq!(message, "still-logging"),
             event => panic!("unexpected event: {event:?}"),
         }
+    }
+
+    #[test]
+    fn run_progress_start_records_progress_event() {
+        let session = Arc::new(MockSession::default());
+        let run = create_run(session.clone());
+
+        let _progress = run.progress("load").start();
+
+        let events = session.events.lock().unwrap();
+        assert!(matches!(
+            events.as_slice(),
+            [Event::Progress(ProgressEvent::Started { node })] if node.name == "load"
+        ));
+    }
+
+    #[test]
+    fn dropped_run_handle_progress_records_no_event() {
+        let session = Arc::new(MockSession::default());
+        let run = create_run(session.clone());
+        let handle = run.handle();
+        drop(run);
+
+        let _progress = handle.progress("late").start();
+
+        let events = session.events.lock().unwrap();
+        assert!(events.is_empty());
     }
 
     #[derive(Debug, Clone, PartialEq, Eq)]

--- a/crates/burn-central-experiment/src/progress.rs
+++ b/crates/burn-central-experiment/src/progress.rs
@@ -1,75 +1,152 @@
-use std::{num::NonZeroU64, sync::atomic::AtomicU64};
+//! Progress tracking primitives for experiment runs.
+//!
+//! Progress is modeled as a tree of named nodes. Starting a node emits a
+//! [`ProgressEvent::Started`] event, updates emit [`ProgressEvent::Updated`], and
+//! explicit or drop-based completion emits [`ProgressEvent::Finished`].
 
-use std::sync::atomic::Ordering;
+use std::{
+    num::NonZeroU64,
+    sync::{
+        Arc,
+        atomic::{AtomicU64, Ordering},
+    },
+};
 
-use crate::ExperimentRunHandle;
+/// Opaque non-zero identifier for a progress node.
+#[derive(Debug, Clone, Copy, serde::Serialize, serde::Deserialize, PartialEq, Eq, Hash)]
+pub struct ProgressId(NonZeroU64);
 
+impl ProgressId {
+    /// Create an identifier from a non-zero numeric value.
+    pub fn new(id: NonZeroU64) -> Self {
+        Self(id)
+    }
+}
+
+/// Metadata describing a progress node when it starts.
+#[derive(Debug, Clone, serde::Serialize, serde::Deserialize)]
+pub struct ProgressNode {
+    /// Unique identifier for this node.
+    pub id: ProgressId,
+    /// Parent node identifier, when this node is nested under another node.
+    pub parent: Option<ProgressId>,
+    /// Human-readable node name.
+    pub name: String,
+    /// Optional unit for progress values, such as `steps` or `bytes`.
+    pub unit: Option<String>,
+    /// Optional expected total for the node.
+    pub total: Option<u64>,
+    /// Extra structured metadata attached by the caller.
+    pub attributes: serde_json::Map<String, serde_json::Value>,
+}
+
+/// Terminal state for a progress node.
+#[derive(Debug, Clone, serde::Serialize, serde::Deserialize)]
+pub enum ProgressStatus {
+    /// The node completed successfully.
+    Success,
+    /// The node stopped before successful completion.
+    Abandonned,
+}
+
+/// Event emitted by a progress node.
+#[derive(Debug, Clone, serde::Serialize, serde::Deserialize)]
+#[serde(tag = "type")]
+pub enum ProgressEvent {
+    /// A node was started.
+    Started {
+        /// The started node metadata.
+        node: ProgressNode,
+    },
+    /// A node's numeric progress changed.
+    Updated {
+        /// The updated node identifier.
+        id: ProgressId,
+        /// The current progress value.
+        current: u64,
+        /// The expected total, if known.
+        total: Option<u64>,
+    },
+    /// A node emitted a human-readable message.
+    Message {
+        /// The node identifier.
+        id: ProgressId,
+        /// The message text.
+        message: String,
+    },
+    /// A node reached a terminal state.
+    Finished {
+        /// The finished node identifier.
+        id: ProgressId,
+        /// The terminal status.
+        status: ProgressStatus,
+        /// Optional completion message.
+        message: Option<String>,
+    },
+}
+
+/// Sink for progress events.
+pub trait ProgressEventReporter: Send + Sync {
+    /// Report one progress event.
+    fn report(&self, event: ProgressEvent);
+}
+
+impl<F> ProgressEventReporter for F
+where
+    F: Fn(ProgressEvent) + Send + Sync,
+{
+    fn report(&self, event: ProgressEvent) {
+        self(event);
+    }
+}
+
+/// Allocates unique progress node identifiers.
+pub trait ProgressIdAllocator: Send + Sync {
+    /// Return the next identifier.
+    fn next_id(&self) -> ProgressId;
+}
+
+/// Lock-free progress identifier allocator.
 #[derive(Debug)]
-pub struct ProgressIdAllocator {
+pub struct AtomicProgressIdAllocator {
     next: AtomicU64,
 }
 
-impl ProgressIdAllocator {
+impl AtomicProgressIdAllocator {
+    /// Create an allocator that starts at identifier `1`.
     pub fn new() -> Self {
         Self {
             next: AtomicU64::new(1),
         }
     }
 
+    /// Allocate the next progress identifier.
     pub fn next(&self) -> ProgressId {
         let id = self.next.fetch_add(1, Ordering::Relaxed);
 
-        // Starts at 1, so this should only fail after overflow/wraparound.
+        // Starts at 1, so this should only fail after overflow or wraparound.
         let id = NonZeroU64::new(id).expect("progress id allocator overflowed or produced zero");
 
         ProgressId(id)
     }
 }
 
-#[derive(Debug, Clone, serde::Serialize, serde::Deserialize)]
-#[serde(tag = "type", content = "data")]
-pub enum ProgressEvent {
-    Started {
-        node: ProgressNode,
-    },
-    Updated {
-        id: ProgressId,
-        current: u64,
-        total: Option<u64>,
-    },
-    Finished {
-        id: ProgressId,
-        status: ProgressStatus,
-        message: Option<String>,
-    },
+impl Default for AtomicProgressIdAllocator {
+    fn default() -> Self {
+        Self::new()
+    }
 }
 
-#[derive(Debug, Clone, serde::Serialize, serde::Deserialize)]
-pub enum ProgressStatus {
-    Success,
-    Abandonned,
+impl ProgressIdAllocator for AtomicProgressIdAllocator {
+    fn next_id(&self) -> ProgressId {
+        self.next()
+    }
 }
 
-#[derive(Debug, Clone, serde::Serialize, serde::Deserialize, PartialEq, Eq, Hash)]
-pub struct ProgressId(NonZeroU64);
-
-#[derive(Debug, Clone, serde::Serialize, serde::Deserialize)]
-pub struct ProgressNode {
-    pub id: ProgressId,
-    pub parent: Option<ProgressId>,
-    pub name: String,
-    pub unit: Option<String>,
-    pub total: Option<u64>,
-    pub attributes: serde_json::Map<String, serde_json::Value>,
-}
-
-pub trait ProgressEventReporter {
-    fn report(&self, event: ProgressEvent);
-}
-
+/// Builder used to configure and start a progress node.
 pub struct ProgressBuilder {
-    reporter: Box<dyn ProgressEventReporter>,
-    id_allocator: ProgressIdAllocator,
+    reporter: Arc<dyn ProgressEventReporter>,
+    id_allocator: Arc<dyn ProgressIdAllocator>,
     parent: Option<ProgressId>,
     name: String,
     unit: Option<String>,
@@ -78,16 +155,36 @@ pub struct ProgressBuilder {
 }
 
 impl ProgressBuilder {
+    /// Create a root progress builder.
+    pub fn new(
+        reporter: Arc<dyn ProgressEventReporter>,
+        id_allocator: Arc<dyn ProgressIdAllocator>,
+        name: impl Into<String>,
+    ) -> Self {
+        Self {
+            reporter,
+            id_allocator,
+            parent: None,
+            name: name.into(),
+            unit: None,
+            total: None,
+            attributes: serde_json::Map::new(),
+        }
+    }
+
+    /// Set the expected total for this node.
     pub fn total(mut self, total: u64) -> Self {
         self.total = Some(total);
         self
     }
 
+    /// Set the unit used by progress values.
     pub fn unit(mut self, unit: impl Into<String>) -> Self {
         self.unit = Some(unit.into());
         self
     }
 
+    /// Add one serializable attribute.
     pub fn attr<T>(mut self, key: impl Into<String>, value: T) -> Result<Self, serde_json::Error>
     where
         T: serde::Serialize,
@@ -97,79 +194,133 @@ impl ProgressBuilder {
         Ok(self)
     }
 
+    /// Add pre-serialized attributes.
+    pub fn attrs<T>(mut self, attributes: T) -> Result<Self, serde_json::Error>
+    where
+        T: IntoIterator<Item = (String, serde_json::Value)>,
+    {
+        for (key, value) in attributes {
+            self.attributes.insert(key, value);
+        }
+        Ok(self)
+    }
+
+    /// Start this node and return a guard for sending updates.
     pub fn start(self) -> ProgressGuard {
-        let id = self.id_allocator.next();
+        let id = self.id_allocator.next_id();
 
         let node = ProgressNode {
             id,
             parent: self.parent,
             name: self.name,
-            total: self.total,
             unit: self.unit,
+            total: self.total,
             attributes: self.attributes,
         };
 
         self.reporter
             .report(ProgressEvent::Started { node: node.clone() });
 
-        ProgressGuard::new(self.reporter, node)
+        ProgressGuard::new(self.reporter, self.id_allocator, node)
     }
 }
 
+/// Active progress node that reports updates and completion.
 pub struct ProgressGuard {
-    reporter: Box<dyn ProgressEventReporter>,
+    reporter: Arc<dyn ProgressEventReporter>,
+    id_allocator: Arc<dyn ProgressIdAllocator>,
     node: ProgressNode,
     current: u64,
+    finished: bool,
 }
 
 impl ProgressGuard {
-    pub fn new(reporter: Box<dyn ProgressEventReporter>, node: ProgressNode) -> Self {
+    /// Create a guard for an already-started node.
+    pub fn new(
+        reporter: Arc<dyn ProgressEventReporter>,
+        id_allocator: Arc<dyn ProgressIdAllocator>,
+        node: ProgressNode,
+    ) -> Self {
         Self {
             reporter,
+            id_allocator,
             node,
             current: 0,
+            finished: false,
         }
     }
 
+    /// Create a builder for a child node.
+    pub fn child(&self, name: impl Into<String>) -> ProgressBuilder {
+        ProgressBuilder {
+            reporter: self.reporter.clone(),
+            id_allocator: self.id_allocator.clone(),
+            parent: Some(self.node.id),
+            name: name.into(),
+            unit: None,
+            total: None,
+            attributes: serde_json::Map::new(),
+        }
+    }
+
+    /// Increase the current progress value by `delta`.
     pub fn inc(&mut self, delta: u64) {
         self.current = self.current.saturating_add(delta);
 
         self.reporter.report(ProgressEvent::Updated {
-            id: self.node.id.clone(),
+            id: self.node.id,
             current: self.current,
             total: self.node.total,
         });
     }
 
+    /// Set the current progress value.
     pub fn set(&mut self, current: u64) {
         self.current = current;
 
         self.reporter.report(ProgressEvent::Updated {
-            id: self.node.id.clone(),
+            id: self.node.id,
             current,
             total: self.node.total,
         });
     }
 
-    pub fn finish(self) {
+    /// Emit a message for this node.
+    pub fn message(&self, message: impl Into<String>) {
+        self.reporter.report(ProgressEvent::Message {
+            id: self.node.id,
+            message: message.into(),
+        });
+    }
+
+    /// Mark the node as successful.
+    pub fn finish(mut self) {
         self.finish_inner(ProgressStatus::Success, None);
     }
 
-    pub fn finish_with_message(self, message: impl Into<String>) {
+    /// Mark the node as successful with a message.
+    pub fn finish_with_message(mut self, message: impl Into<String>) {
         self.finish_inner(ProgressStatus::Success, Some(message.into()));
     }
 
-    pub fn abandon(self) {
+    /// Mark the node as abandoned.
+    pub fn abandon(mut self) {
         self.finish_inner(ProgressStatus::Abandonned, None);
     }
 
-    pub fn abandon_with_message(self, message: impl Into<String>) {
+    /// Mark the node as abandoned with a message.
+    pub fn abandon_with_message(mut self, message: impl Into<String>) {
         self.finish_inner(ProgressStatus::Abandonned, Some(message.into()));
     }
 
-    fn finish_inner(&self, status: ProgressStatus, message: Option<String>) {
+    fn finish_inner(&mut self, status: ProgressStatus, message: Option<String>) {
+        if self.finished {
+            return;
+        }
+
+        self.finished = true;
         self.reporter.report(ProgressEvent::Finished {
-            id: self.node.id.clone(),
+            id: self.node.id,
             status,
             message,
         });

--- a/crates/burn-central-experiment/src/progress.rs
+++ b/crates/burn-central-experiment/src/progress.rs
@@ -332,3 +332,122 @@ impl Drop for ProgressGuard {
         self.finish_inner(ProgressStatus::Abandonned, None);
     }
 }
+
+#[cfg(test)]
+mod tests {
+    use std::sync::Mutex;
+
+    use serde_json::json;
+
+    use super::*;
+
+    #[derive(Default)]
+    struct MockReporter {
+        events: Mutex<Vec<ProgressEvent>>,
+    }
+
+    impl MockReporter {
+        fn events(&self) -> Vec<ProgressEvent> {
+            self.events.lock().unwrap().clone()
+        }
+    }
+
+    impl ProgressEventReporter for MockReporter {
+        fn report(&self, event: ProgressEvent) {
+            self.events.lock().unwrap().push(event);
+        }
+    }
+
+    fn builder(reporter: Arc<MockReporter>, name: &str) -> ProgressBuilder {
+        ProgressBuilder::new(
+            reporter,
+            Arc::new(AtomicProgressIdAllocator::new()),
+            name.to_string(),
+        )
+    }
+
+    #[test]
+    fn start_reports_configured_node() {
+        let reporter = Arc::new(MockReporter::default());
+
+        let _guard = builder(reporter.clone(), "load")
+            .total(12)
+            .unit("items")
+            .attr("split", "train")
+            .unwrap()
+            .start();
+
+        let events = reporter.events();
+        let ProgressEvent::Started { node } = &events[0] else {
+            panic!("unexpected event: {:?}", events[0]);
+        };
+        assert_eq!(node.name, "load");
+        assert_eq!(node.total, Some(12));
+        assert_eq!(node.unit.as_deref(), Some("items"));
+        assert_eq!(node.attributes.get("split"), Some(&json!("train")));
+    }
+
+    #[test]
+    fn child_start_reports_parent_id() {
+        let reporter = Arc::new(MockReporter::default());
+        let parent = builder(reporter.clone(), "parent").start();
+
+        let _child = parent.child("child").start();
+
+        let events = reporter.events();
+        let ProgressEvent::Started { node: parent } = events[0].clone() else {
+            panic!("unexpected event: {:?}", events[0]);
+        };
+        let ProgressEvent::Started { node: child } = events[1].clone() else {
+            panic!("unexpected event: {:?}", events[1]);
+        };
+        assert_eq!(child.parent, Some(parent.id));
+    }
+
+    #[test]
+    fn inc_reports_updated_progress() {
+        let reporter = Arc::new(MockReporter::default());
+        let mut guard = builder(reporter.clone(), "items").total(8).start();
+
+        guard.inc(3);
+
+        let events = reporter.events();
+        let ProgressEvent::Updated { current, total, .. } = &events[1] else {
+            panic!("unexpected event: {:?}", events[1]);
+        };
+        assert_eq!((*current, *total), (3, Some(8)));
+    }
+
+    #[test]
+    fn finish_reports_one_success_completion() {
+        let reporter = Arc::new(MockReporter::default());
+
+        builder(reporter.clone(), "node").start().finish();
+
+        let events = reporter.events();
+        let finished: Vec<_> = events
+            .iter()
+            .filter_map(|event| match event {
+                ProgressEvent::Finished { status, .. } => Some(status),
+                _ => None,
+            })
+            .collect();
+        assert!(matches!(finished.as_slice(), [ProgressStatus::Success]));
+    }
+
+    #[test]
+    fn drop_reports_abandoned_completion() {
+        let reporter = Arc::new(MockReporter::default());
+
+        drop(builder(reporter.clone(), "node").start());
+
+        let events = reporter.events();
+        assert!(matches!(
+            events.last(),
+            Some(ProgressEvent::Finished {
+                status: ProgressStatus::Abandonned,
+                ..
+            })
+        ));
+    }
+}

--- a/crates/burn-central-experiment/src/progress.rs
+++ b/crates/burn-central-experiment/src/progress.rs
@@ -236,7 +236,7 @@ pub struct ProgressGuard {
 
 impl ProgressGuard {
     /// Create a guard for an already-started node.
-    pub fn new(
+    fn new(
         reporter: Arc<dyn ProgressEventReporter>,
         id_allocator: Arc<dyn ProgressIdAllocator>,
         node: ProgressNode,

--- a/crates/burn-central-experiment/src/progress.rs
+++ b/crates/burn-central-experiment/src/progress.rs
@@ -156,7 +156,7 @@ pub struct ProgressBuilder {
 
 impl ProgressBuilder {
     /// Create a root progress builder.
-    pub fn new(
+    pub(crate) fn new(
         reporter: Arc<dyn ProgressEventReporter>,
         id_allocator: Arc<dyn ProgressIdAllocator>,
         name: impl Into<String>,

--- a/crates/burn-central-experiment/src/progress.rs
+++ b/crates/burn-central-experiment/src/progress.rs
@@ -46,7 +46,7 @@ pub enum ProgressStatus {
     /// The node completed successfully.
     Success,
     /// The node stopped before successful completion.
-    Abandonned,
+    Abandoned,
 }
 
 /// Event emitted by a progress node.
@@ -119,16 +119,6 @@ impl AtomicProgressIdAllocator {
             next: AtomicU64::new(1),
         }
     }
-
-    /// Allocate the next progress identifier.
-    pub fn next(&self) -> ProgressId {
-        let id = self.next.fetch_add(1, Ordering::Relaxed);
-
-        // Starts at 1, so this should only fail after overflow or wraparound.
-        let id = NonZeroU64::new(id).expect("progress id allocator overflowed or produced zero");
-
-        ProgressId(id)
-    }
 }
 
 impl Default for AtomicProgressIdAllocator {
@@ -139,7 +129,12 @@ impl Default for AtomicProgressIdAllocator {
 
 impl ProgressIdAllocator for AtomicProgressIdAllocator {
     fn next_id(&self) -> ProgressId {
-        self.next()
+        let id = self.next.fetch_add(1, Ordering::Relaxed);
+
+        // Starts at 1, so this should only fail after overflow or wraparound.
+        let id = NonZeroU64::new(id).expect("progress id allocator overflowed or produced zero");
+
+        ProgressId(id)
     }
 }
 
@@ -305,12 +300,12 @@ impl ProgressGuard {
 
     /// Mark the node as abandoned.
     pub fn abandon(mut self) {
-        self.finish_inner(ProgressStatus::Abandonned, None);
+        self.finish_inner(ProgressStatus::Abandoned, None);
     }
 
     /// Mark the node as abandoned with a message.
     pub fn abandon_with_message(mut self, message: impl Into<String>) {
-        self.finish_inner(ProgressStatus::Abandonned, Some(message.into()));
+        self.finish_inner(ProgressStatus::Abandoned, Some(message.into()));
     }
 
     fn finish_inner(&mut self, status: ProgressStatus, message: Option<String>) {
@@ -329,7 +324,7 @@ impl ProgressGuard {
 
 impl Drop for ProgressGuard {
     fn drop(&mut self) {
-        self.finish_inner(ProgressStatus::Abandonned, None);
+        self.finish_inner(ProgressStatus::Abandoned, None);
     }
 }
 
@@ -445,7 +440,7 @@ mod tests {
         assert!(matches!(
             events.last(),
             Some(ProgressEvent::Finished {
-                status: ProgressStatus::Abandonned,
+                status: ProgressStatus::Abandoned,
                 ..
             })
         ));

--- a/crates/burn-central-experiment/src/progress.rs
+++ b/crates/burn-central-experiment/src/progress.rs
@@ -1,0 +1,183 @@
+use std::{num::NonZeroU64, sync::atomic::AtomicU64};
+
+use std::sync::atomic::Ordering;
+
+use crate::ExperimentRunHandle;
+
+#[derive(Debug)]
+pub struct ProgressIdAllocator {
+    next: AtomicU64,
+}
+
+impl ProgressIdAllocator {
+    pub fn new() -> Self {
+        Self {
+            next: AtomicU64::new(1),
+        }
+    }
+
+    pub fn next(&self) -> ProgressId {
+        let id = self.next.fetch_add(1, Ordering::Relaxed);
+
+        // Starts at 1, so this should only fail after overflow/wraparound.
+        let id = NonZeroU64::new(id).expect("progress id allocator overflowed or produced zero");
+
+        ProgressId(id)
+    }
+}
+
+#[derive(Debug, Clone, serde::Serialize, serde::Deserialize)]
+#[serde(tag = "type", content = "data")]
+pub enum ProgressEvent {
+    Started {
+        node: ProgressNode,
+    },
+    Updated {
+        id: ProgressId,
+        current: u64,
+        total: Option<u64>,
+    },
+    Finished {
+        id: ProgressId,
+        status: ProgressStatus,
+        message: Option<String>,
+    },
+}
+
+#[derive(Debug, Clone, serde::Serialize, serde::Deserialize)]
+pub enum ProgressStatus {
+    Success,
+    Abandonned,
+}
+
+#[derive(Debug, Clone, serde::Serialize, serde::Deserialize, PartialEq, Eq, Hash)]
+pub struct ProgressId(NonZeroU64);
+
+#[derive(Debug, Clone, serde::Serialize, serde::Deserialize)]
+pub struct ProgressNode {
+    pub id: ProgressId,
+    pub parent: Option<ProgressId>,
+    pub name: String,
+    pub unit: Option<String>,
+    pub total: Option<u64>,
+    pub attributes: serde_json::Map<String, serde_json::Value>,
+}
+
+pub trait ProgressEventReporter {
+    fn report(&self, event: ProgressEvent);
+}
+
+pub struct ProgressBuilder {
+    reporter: Box<dyn ProgressEventReporter>,
+    id_allocator: ProgressIdAllocator,
+    parent: Option<ProgressId>,
+    name: String,
+    unit: Option<String>,
+    total: Option<u64>,
+    attributes: serde_json::Map<String, serde_json::Value>,
+}
+
+impl ProgressBuilder {
+    pub fn total(mut self, total: u64) -> Self {
+        self.total = Some(total);
+        self
+    }
+
+    pub fn unit(mut self, unit: impl Into<String>) -> Self {
+        self.unit = Some(unit.into());
+        self
+    }
+
+    pub fn attr<T>(mut self, key: impl Into<String>, value: T) -> Result<Self, serde_json::Error>
+    where
+        T: serde::Serialize,
+    {
+        self.attributes
+            .insert(key.into(), serde_json::to_value(value)?);
+        Ok(self)
+    }
+
+    pub fn start(self) -> ProgressGuard {
+        let id = self.id_allocator.next();
+
+        let node = ProgressNode {
+            id,
+            parent: self.parent,
+            name: self.name,
+            total: self.total,
+            unit: self.unit,
+            attributes: self.attributes,
+        };
+
+        self.reporter
+            .report(ProgressEvent::Started { node: node.clone() });
+
+        ProgressGuard::new(self.reporter, node)
+    }
+}
+
+pub struct ProgressGuard {
+    reporter: Box<dyn ProgressEventReporter>,
+    node: ProgressNode,
+    current: u64,
+}
+
+impl ProgressGuard {
+    pub fn new(reporter: Box<dyn ProgressEventReporter>, node: ProgressNode) -> Self {
+        Self {
+            reporter,
+            node,
+            current: 0,
+        }
+    }
+
+    pub fn inc(&mut self, delta: u64) {
+        self.current = self.current.saturating_add(delta);
+
+        self.reporter.report(ProgressEvent::Updated {
+            id: self.node.id.clone(),
+            current: self.current,
+            total: self.node.total,
+        });
+    }
+
+    pub fn set(&mut self, current: u64) {
+        self.current = current;
+
+        self.reporter.report(ProgressEvent::Updated {
+            id: self.node.id.clone(),
+            current,
+            total: self.node.total,
+        });
+    }
+
+    pub fn finish(self) {
+        self.finish_inner(ProgressStatus::Success, None);
+    }
+
+    pub fn finish_with_message(self, message: impl Into<String>) {
+        self.finish_inner(ProgressStatus::Success, Some(message.into()));
+    }
+
+    pub fn abandon(self) {
+        self.finish_inner(ProgressStatus::Abandonned, None);
+    }
+
+    pub fn abandon_with_message(self, message: impl Into<String>) {
+        self.finish_inner(ProgressStatus::Abandonned, Some(message.into()));
+    }
+
+    fn finish_inner(&self, status: ProgressStatus, message: Option<String>) {
+        self.reporter.report(ProgressEvent::Finished {
+            id: self.node.id.clone(),
+            status,
+            message,
+        });
+    }
+}
+
+impl Drop for ProgressGuard {
+    fn drop(&mut self) {
+        self.finish_inner(ProgressStatus::Abandonned, None);
+    }
+}

--- a/crates/burn-central-experiment/src/remote/base.rs
+++ b/crates/burn-central-experiment/src/remote/base.rs
@@ -123,6 +123,7 @@ impl ExperimentSession for RemoteExperimentSession {
             } => ExperimentMessage::InputUsed(InputUsed::Artifact {
                 artifact_id: reference.id,
             }),
+            Event::Progress(progress_event) => todo!(),
         };
 
         self.send(message)

--- a/crates/burn-central-experiment/src/remote/base.rs
+++ b/crates/burn-central-experiment/src/remote/base.rs
@@ -123,7 +123,7 @@ impl ExperimentSession for RemoteExperimentSession {
             } => ExperimentMessage::InputUsed(InputUsed::Artifact {
                 artifact_id: reference.id,
             }),
-            Event::Progress(progress_event) => todo!(),
+            Event::Progress(_progress_event) => todo!(),
         };
 
         self.send(message)

--- a/crates/burn-central-experiment/src/remote/base.rs
+++ b/crates/burn-central-experiment/src/remote/base.rs
@@ -123,7 +123,10 @@ impl ExperimentSession for RemoteExperimentSession {
             } => ExperimentMessage::InputUsed(InputUsed::Artifact {
                 artifact_id: reference.id,
             }),
-            Event::Progress(_progress_event) => todo!(),
+            Event::Progress(_progress_event) => {
+                // TODO: Implement progress event forwarding to remote session
+                return Ok(());
+            }
         };
 
         self.send(message)

--- a/crates/burn-central-experiment/src/session.rs
+++ b/crates/burn-central-experiment/src/session.rs
@@ -4,7 +4,7 @@ use burn_central_artifact::bundle::FsBundle;
 
 use crate::{
     ArtifactKind, ExperimentId, MetricSpec, MetricValue, error::ExperimentError,
-    reader::ArtifactRef,
+    progress::ProgressEvent, reader::ArtifactRef,
 };
 
 #[derive(Debug, Clone)]
@@ -33,6 +33,7 @@ pub enum Event {
         experiment_id: ExperimentId,
         reference: ArtifactRef,
     },
+    Progress(ProgressEvent),
 }
 
 /// Final completion state recorded for an experiment run.


### PR DESCRIPTION
This PR adds a generic task progress tracking API.

The next steps are to add an integration for this API with `burn-train` to allow tracking training progress.