### PR TITLE
Fix: update checkpointer and record

### DIFF
--- a/.cargo/config.toml
+++ b/.cargo/config.toml
@@ -1,5 +1,2 @@
 [alias]
 xtask = "run --target-dir target/xtask/debug --package xtask --bin xtask --"
-
-[patch."https://github.com/tracel-ai/burn"]
-burn = { path = "../burn/crates/burn" }

--- a/.cargo/config.toml
+++ b/.cargo/config.toml
@@ -1,2 +1,5 @@
 [alias]
 xtask = "run --target-dir target/xtask/debug --package xtask --bin xtask --"
+
+[patch."https://github.com/tracel-ai/burn"]
+burn = { path = "../burn/crates/burn" }

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -242,16 +242,6 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "2af50177e190e07a26ab74f8b1efbfe2ef87da2116221318cb1c2e82baf7de06"
 
 [[package]]
-name = "bincode"
-version = "2.0.1"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "36eaf5d7b090263e8150820482d5d93cd964a81e4019913c972f4edcc6edb740"
-dependencies = [
- "serde",
- "unty",
-]
-
-[[package]]
 name = "bit-set"
 version = "0.10.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -311,12 +301,13 @@ checksum = "72f5acc6cb2ba439de613abc23857ec3d78374d8ed5ac84e9d11336e87da8649"
 [[package]]
 name = "burn"
 version = "0.22.0-pre.1"
-source = "git+https://github.com/tracel-ai/burn?rev=1b6dd60361115a0efb5b67c43cb75cd856b30498#1b6dd60361115a0efb5b67c43cb75cd856b30498"
+source = "git+https://github.com/tracel-ai/burn?rev=862ef266ade864d6fc48df3687e9f8b911c7d05e#862ef266ade864d6fc48df3687e9f8b911c7d05e"
 dependencies = [
  "burn-autodiff",
  "burn-core",
  "burn-ndarray",
  "burn-nn",
+ "burn-optim",
  "burn-std",
  "burn-train",
 ]
@@ -324,7 +315,7 @@ dependencies = [
 [[package]]
 name = "burn-autodiff"
 version = "0.22.0-pre.1"
-source = "git+https://github.com/tracel-ai/burn?rev=1b6dd60361115a0efb5b67c43cb75cd856b30498#1b6dd60361115a0efb5b67c43cb75cd856b30498"
+source = "git+https://github.com/tracel-ai/burn?rev=862ef266ade864d6fc48df3687e9f8b911c7d05e#862ef266ade864d6fc48df3687e9f8b911c7d05e"
 dependencies = [
  "burn-backend",
  "burn-std",
@@ -341,7 +332,7 @@ dependencies = [
 [[package]]
 name = "burn-backend"
 version = "0.22.0-pre.1"
-source = "git+https://github.com/tracel-ai/burn?rev=1b6dd60361115a0efb5b67c43cb75cd856b30498#1b6dd60361115a0efb5b67c43cb75cd856b30498"
+source = "git+https://github.com/tracel-ai/burn?rev=862ef266ade864d6fc48df3687e9f8b911c7d05e#862ef266ade864d6fc48df3687e9f8b911c7d05e"
 dependencies = [
  "burn-std",
  "bytemuck",
@@ -350,6 +341,7 @@ dependencies = [
  "enumset",
  "hashbrown 0.16.1",
  "num-traits",
+ "oneshot",
  "portable-atomic-util",
  "rand 0.10.1",
  "rand_distr",
@@ -358,19 +350,30 @@ dependencies = [
 ]
 
 [[package]]
+name = "burn-backend-extension"
+version = "0.22.0-pre.1"
+source = "git+https://github.com/tracel-ai/burn?rev=862ef266ade864d6fc48df3687e9f8b911c7d05e#862ef266ade864d6fc48df3687e9f8b911c7d05e"
+dependencies = [
+ "proc-macro2",
+ "quote",
+ "syn",
+]
+
+[[package]]
 name = "burn-core"
 version = "0.22.0-pre.1"
-source = "git+https://github.com/tracel-ai/burn?rev=1b6dd60361115a0efb5b67c43cb75cd856b30498#1b6dd60361115a0efb5b67c43cb75cd856b30498"
+source = "git+https://github.com/tracel-ai/burn?rev=862ef266ade864d6fc48df3687e9f8b911c7d05e#862ef266ade864d6fc48df3687e9f8b911c7d05e"
 dependencies = [
  "ahash",
- "bincode",
+ "burn-backend",
+ "burn-backend-extension",
  "burn-dataset",
  "burn-derive",
+ "burn-dispatch",
+ "burn-pack",
  "burn-std",
  "burn-tensor",
- "data-encoding",
  "derive-new",
- "flate2",
  "half",
  "hashbrown 0.16.1",
  "log",
@@ -378,18 +381,15 @@ dependencies = [
  "portable-atomic",
  "portable-atomic-util",
  "rand 0.10.1",
- "regex",
- "rmp-serde",
  "serde",
  "serde_json",
  "spin",
- "uuid",
 ]
 
 [[package]]
 name = "burn-cpu"
 version = "0.22.0-pre.1"
-source = "git+https://github.com/tracel-ai/burn?rev=1b6dd60361115a0efb5b67c43cb75cd856b30498#1b6dd60361115a0efb5b67c43cb75cd856b30498"
+source = "git+https://github.com/tracel-ai/burn?rev=862ef266ade864d6fc48df3687e9f8b911c7d05e#862ef266ade864d6fc48df3687e9f8b911c7d05e"
 dependencies = [
  "burn-backend",
  "burn-cubecl",
@@ -399,7 +399,7 @@ dependencies = [
 [[package]]
 name = "burn-cubecl"
 version = "0.22.0-pre.1"
-source = "git+https://github.com/tracel-ai/burn?rev=1b6dd60361115a0efb5b67c43cb75cd856b30498#1b6dd60361115a0efb5b67c43cb75cd856b30498"
+source = "git+https://github.com/tracel-ai/burn?rev=862ef266ade864d6fc48df3687e9f8b911c7d05e#862ef266ade864d6fc48df3687e9f8b911c7d05e"
 dependencies = [
  "burn-backend",
  "burn-cubecl-fusion",
@@ -418,7 +418,7 @@ dependencies = [
 [[package]]
 name = "burn-cubecl-fusion"
 version = "0.22.0-pre.1"
-source = "git+https://github.com/tracel-ai/burn?rev=1b6dd60361115a0efb5b67c43cb75cd856b30498#1b6dd60361115a0efb5b67c43cb75cd856b30498"
+source = "git+https://github.com/tracel-ai/burn?rev=862ef266ade864d6fc48df3687e9f8b911c7d05e#862ef266ade864d6fc48df3687e9f8b911c7d05e"
 dependencies = [
  "burn-backend",
  "burn-fusion",
@@ -435,7 +435,7 @@ dependencies = [
 [[package]]
 name = "burn-cuda"
 version = "0.22.0-pre.1"
-source = "git+https://github.com/tracel-ai/burn?rev=1b6dd60361115a0efb5b67c43cb75cd856b30498#1b6dd60361115a0efb5b67c43cb75cd856b30498"
+source = "git+https://github.com/tracel-ai/burn?rev=862ef266ade864d6fc48df3687e9f8b911c7d05e#862ef266ade864d6fc48df3687e9f8b911c7d05e"
 dependencies = [
  "burn-backend",
  "burn-cubecl",
@@ -445,7 +445,7 @@ dependencies = [
 [[package]]
 name = "burn-dataset"
 version = "0.22.0-pre.1"
-source = "git+https://github.com/tracel-ai/burn?rev=1b6dd60361115a0efb5b67c43cb75cd856b30498#1b6dd60361115a0efb5b67c43cb75cd856b30498"
+source = "git+https://github.com/tracel-ai/burn?rev=862ef266ade864d6fc48df3687e9f8b911c7d05e#862ef266ade864d6fc48df3687e9f8b911c7d05e"
 dependencies = [
  "csv",
  "derive-new",
@@ -463,7 +463,7 @@ dependencies = [
 [[package]]
 name = "burn-derive"
 version = "0.22.0-pre.1"
-source = "git+https://github.com/tracel-ai/burn?rev=1b6dd60361115a0efb5b67c43cb75cd856b30498#1b6dd60361115a0efb5b67c43cb75cd856b30498"
+source = "git+https://github.com/tracel-ai/burn?rev=862ef266ade864d6fc48df3687e9f8b911c7d05e#862ef266ade864d6fc48df3687e9f8b911c7d05e"
 dependencies = [
  "derive-new",
  "proc-macro2",
@@ -474,7 +474,7 @@ dependencies = [
 [[package]]
 name = "burn-dispatch"
 version = "0.22.0-pre.1"
-source = "git+https://github.com/tracel-ai/burn?rev=1b6dd60361115a0efb5b67c43cb75cd856b30498#1b6dd60361115a0efb5b67c43cb75cd856b30498"
+source = "git+https://github.com/tracel-ai/burn?rev=862ef266ade864d6fc48df3687e9f8b911c7d05e#862ef266ade864d6fc48df3687e9f8b911c7d05e"
 dependencies = [
  "burn-autodiff",
  "burn-backend",
@@ -491,7 +491,7 @@ dependencies = [
 [[package]]
 name = "burn-flex"
 version = "0.22.0-pre.1"
-source = "git+https://github.com/tracel-ai/burn?rev=1b6dd60361115a0efb5b67c43cb75cd856b30498#1b6dd60361115a0efb5b67c43cb75cd856b30498"
+source = "git+https://github.com/tracel-ai/burn?rev=862ef266ade864d6fc48df3687e9f8b911c7d05e#862ef266ade864d6fc48df3687e9f8b911c7d05e"
 dependencies = [
  "aligned-vec",
  "burn-backend",
@@ -503,13 +503,16 @@ dependencies = [
  "libm",
  "macerator",
  "num-traits",
+ "once_cell",
+ "portable-atomic",
+ "portable-atomic-util",
  "rayon",
 ]
 
 [[package]]
 name = "burn-fusion"
 version = "0.22.0-pre.1"
-source = "git+https://github.com/tracel-ai/burn?rev=1b6dd60361115a0efb5b67c43cb75cd856b30498#1b6dd60361115a0efb5b67c43cb75cd856b30498"
+source = "git+https://github.com/tracel-ai/burn?rev=862ef266ade864d6fc48df3687e9f8b911c7d05e#862ef266ade864d6fc48df3687e9f8b911c7d05e"
 dependencies = [
  "burn-backend",
  "burn-ir",
@@ -526,7 +529,7 @@ dependencies = [
 [[package]]
 name = "burn-ir"
 version = "0.22.0-pre.1"
-source = "git+https://github.com/tracel-ai/burn?rev=1b6dd60361115a0efb5b67c43cb75cd856b30498#1b6dd60361115a0efb5b67c43cb75cd856b30498"
+source = "git+https://github.com/tracel-ai/burn?rev=862ef266ade864d6fc48df3687e9f8b911c7d05e#862ef266ade864d6fc48df3687e9f8b911c7d05e"
 dependencies = [
  "burn-backend",
  "hashbrown 0.16.1",
@@ -536,7 +539,7 @@ dependencies = [
 [[package]]
 name = "burn-ndarray"
 version = "0.22.0-pre.1"
-source = "git+https://github.com/tracel-ai/burn?rev=1b6dd60361115a0efb5b67c43cb75cd856b30498#1b6dd60361115a0efb5b67c43cb75cd856b30498"
+source = "git+https://github.com/tracel-ai/burn?rev=862ef266ade864d6fc48df3687e9f8b911c7d05e#862ef266ade864d6fc48df3687e9f8b911c7d05e"
 dependencies = [
  "atomic_float",
  "burn-autodiff",
@@ -558,7 +561,7 @@ dependencies = [
 [[package]]
 name = "burn-nn"
 version = "0.22.0-pre.1"
-source = "git+https://github.com/tracel-ai/burn?rev=1b6dd60361115a0efb5b67c43cb75cd856b30498#1b6dd60361115a0efb5b67c43cb75cd856b30498"
+source = "git+https://github.com/tracel-ai/burn?rev=862ef266ade864d6fc48df3687e9f8b911c7d05e#862ef266ade864d6fc48df3687e9f8b911c7d05e"
 dependencies = [
  "burn-core",
  "num-traits",
@@ -567,9 +570,11 @@ dependencies = [
 [[package]]
 name = "burn-optim"
 version = "0.22.0-pre.1"
-source = "git+https://github.com/tracel-ai/burn?rev=1b6dd60361115a0efb5b67c43cb75cd856b30498#1b6dd60361115a0efb5b67c43cb75cd856b30498"
+source = "git+https://github.com/tracel-ai/burn?rev=862ef266ade864d6fc48df3687e9f8b911c7d05e#862ef266ade864d6fc48df3687e9f8b911c7d05e"
 dependencies = [
  "burn-core",
+ "burn-derive",
+ "burn-pack",
  "derive-new",
  "hashbrown 0.16.1",
  "log",
@@ -578,9 +583,20 @@ dependencies = [
 ]
 
 [[package]]
+name = "burn-pack"
+version = "0.22.0-pre.1"
+source = "git+https://github.com/tracel-ai/burn?rev=862ef266ade864d6fc48df3687e9f8b911c7d05e#862ef266ade864d6fc48df3687e9f8b911c7d05e"
+dependencies = [
+ "burn-std",
+ "byteorder",
+ "ciborium",
+ "serde",
+]
+
+[[package]]
 name = "burn-rocm"
 version = "0.22.0-pre.1"
-source = "git+https://github.com/tracel-ai/burn?rev=1b6dd60361115a0efb5b67c43cb75cd856b30498#1b6dd60361115a0efb5b67c43cb75cd856b30498"
+source = "git+https://github.com/tracel-ai/burn?rev=862ef266ade864d6fc48df3687e9f8b911c7d05e#862ef266ade864d6fc48df3687e9f8b911c7d05e"
 dependencies = [
  "burn-backend",
  "burn-cubecl",
@@ -590,13 +606,14 @@ dependencies = [
 [[package]]
 name = "burn-std"
 version = "0.22.0-pre.1"
-source = "git+https://github.com/tracel-ai/burn?rev=1b6dd60361115a0efb5b67c43cb75cd856b30498#1b6dd60361115a0efb5b67c43cb75cd856b30498"
+source = "git+https://github.com/tracel-ai/burn?rev=862ef266ade864d6fc48df3687e9f8b911c7d05e#862ef266ade864d6fc48df3687e9f8b911c7d05e"
 dependencies = [
  "ahash",
  "bytemuck",
  "bytes",
  "cubecl-common",
  "cubecl-zspace",
+ "data-encoding",
  "derive-new",
  "enumset",
  "half",
@@ -609,12 +626,13 @@ dependencies = [
  "smallvec",
  "spin",
  "thiserror 2.0.18",
+ "uuid",
 ]
 
 [[package]]
 name = "burn-tch"
 version = "0.22.0-pre.1"
-source = "git+https://github.com/tracel-ai/burn?rev=1b6dd60361115a0efb5b67c43cb75cd856b30498#1b6dd60361115a0efb5b67c43cb75cd856b30498"
+source = "git+https://github.com/tracel-ai/burn?rev=862ef266ade864d6fc48df3687e9f8b911c7d05e#862ef266ade864d6fc48df3687e9f8b911c7d05e"
 dependencies = [
  "burn-backend",
  "cc",
@@ -627,14 +645,13 @@ dependencies = [
 [[package]]
 name = "burn-tensor"
 version = "0.22.0-pre.1"
-source = "git+https://github.com/tracel-ai/burn?rev=1b6dd60361115a0efb5b67c43cb75cd856b30498#1b6dd60361115a0efb5b67c43cb75cd856b30498"
+source = "git+https://github.com/tracel-ai/burn?rev=862ef266ade864d6fc48df3687e9f8b911c7d05e#862ef266ade864d6fc48df3687e9f8b911c7d05e"
 dependencies = [
  "burn-backend",
  "burn-dispatch",
  "burn-std",
  "colored",
  "derive-new",
- "enumset",
  "num-traits",
  "serde",
 ]
@@ -642,7 +659,7 @@ dependencies = [
 [[package]]
 name = "burn-train"
 version = "0.22.0-pre.1"
-source = "git+https://github.com/tracel-ai/burn?rev=1b6dd60361115a0efb5b67c43cb75cd856b30498#1b6dd60361115a0efb5b67c43cb75cd856b30498"
+source = "git+https://github.com/tracel-ai/burn?rev=862ef266ade864d6fc48df3687e9f8b911c7d05e#862ef266ade864d6fc48df3687e9f8b911c7d05e"
 dependencies = [
  "async-channel",
  "burn-core",
@@ -663,7 +680,7 @@ dependencies = [
 [[package]]
 name = "burn-wgpu"
 version = "0.22.0-pre.1"
-source = "git+https://github.com/tracel-ai/burn?rev=1b6dd60361115a0efb5b67c43cb75cd856b30498#1b6dd60361115a0efb5b67c43cb75cd856b30498"
+source = "git+https://github.com/tracel-ai/burn?rev=862ef266ade864d6fc48df3687e9f8b911c7d05e#862ef266ade864d6fc48df3687e9f8b911c7d05e"
 dependencies = [
  "burn-backend",
  "burn-cubecl",
@@ -1230,7 +1247,7 @@ dependencies = [
 [[package]]
 name = "cubecl"
 version = "0.11.0-pre.1"
-source = "git+https://github.com/tracel-ai/cubecl?rev=1d628d7e8fa6ac27c67195b35736de0b63cc2839#1d628d7e8fa6ac27c67195b35736de0b63cc2839"
+source = "git+https://github.com/tracel-ai/cubecl?rev=a30791301897f3dc080fd85df39cc24658c57c84#a30791301897f3dc080fd85df39cc24658c57c84"
 dependencies = [
  "cubecl-core",
  "cubecl-cpu",
@@ -1246,7 +1263,7 @@ dependencies = [
 [[package]]
 name = "cubecl-common"
 version = "0.11.0-pre.1"
-source = "git+https://github.com/tracel-ai/cubecl?rev=1d628d7e8fa6ac27c67195b35736de0b63cc2839#1d628d7e8fa6ac27c67195b35736de0b63cc2839"
+source = "git+https://github.com/tracel-ai/cubecl?rev=a30791301897f3dc080fd85df39cc24658c57c84#a30791301897f3dc080fd85df39cc24658c57c84"
 dependencies = [
  "backtrace",
  "bytemuck",
@@ -1287,7 +1304,7 @@ dependencies = [
 [[package]]
 name = "cubecl-core"
 version = "0.11.0-pre.1"
-source = "git+https://github.com/tracel-ai/cubecl?rev=1d628d7e8fa6ac27c67195b35736de0b63cc2839#1d628d7e8fa6ac27c67195b35736de0b63cc2839"
+source = "git+https://github.com/tracel-ai/cubecl?rev=a30791301897f3dc080fd85df39cc24658c57c84#a30791301897f3dc080fd85df39cc24658c57c84"
 dependencies = [
  "bitflags",
  "bytemuck",
@@ -1316,7 +1333,7 @@ dependencies = [
 [[package]]
 name = "cubecl-cpp"
 version = "0.11.0-pre.1"
-source = "git+https://github.com/tracel-ai/cubecl?rev=1d628d7e8fa6ac27c67195b35736de0b63cc2839#1d628d7e8fa6ac27c67195b35736de0b63cc2839"
+source = "git+https://github.com/tracel-ai/cubecl?rev=a30791301897f3dc080fd85df39cc24658c57c84#a30791301897f3dc080fd85df39cc24658c57c84"
 dependencies = [
  "bytemuck",
  "cubecl-common",
@@ -1332,7 +1349,7 @@ dependencies = [
 [[package]]
 name = "cubecl-cpu"
 version = "0.11.0-pre.1"
-source = "git+https://github.com/tracel-ai/cubecl?rev=1d628d7e8fa6ac27c67195b35736de0b63cc2839#1d628d7e8fa6ac27c67195b35736de0b63cc2839"
+source = "git+https://github.com/tracel-ai/cubecl?rev=a30791301897f3dc080fd85df39cc24658c57c84#a30791301897f3dc080fd85df39cc24658c57c84"
 dependencies = [
  "bytemuck",
  "cubecl-common",
@@ -1355,7 +1372,7 @@ dependencies = [
 [[package]]
 name = "cubecl-cuda"
 version = "0.11.0-pre.1"
-source = "git+https://github.com/tracel-ai/cubecl?rev=1d628d7e8fa6ac27c67195b35736de0b63cc2839#1d628d7e8fa6ac27c67195b35736de0b63cc2839"
+source = "git+https://github.com/tracel-ai/cubecl?rev=a30791301897f3dc080fd85df39cc24658c57c84#a30791301897f3dc080fd85df39cc24658c57c84"
 dependencies = [
  "bytemuck",
  "cubecl-common",
@@ -1373,7 +1390,7 @@ dependencies = [
 [[package]]
 name = "cubecl-hip"
 version = "0.11.0-pre.1"
-source = "git+https://github.com/tracel-ai/cubecl?rev=1d628d7e8fa6ac27c67195b35736de0b63cc2839#1d628d7e8fa6ac27c67195b35736de0b63cc2839"
+source = "git+https://github.com/tracel-ai/cubecl?rev=a30791301897f3dc080fd85df39cc24658c57c84#a30791301897f3dc080fd85df39cc24658c57c84"
 dependencies = [
  "bytemuck",
  "cubecl-common",
@@ -1402,7 +1419,7 @@ dependencies = [
 [[package]]
 name = "cubecl-ir"
 version = "0.11.0-pre.1"
-source = "git+https://github.com/tracel-ai/cubecl?rev=1d628d7e8fa6ac27c67195b35736de0b63cc2839#1d628d7e8fa6ac27c67195b35736de0b63cc2839"
+source = "git+https://github.com/tracel-ai/cubecl?rev=a30791301897f3dc080fd85df39cc24658c57c84#a30791301897f3dc080fd85df39cc24658c57c84"
 dependencies = [
  "bumpalo",
  "cubecl-common",
@@ -1426,7 +1443,7 @@ dependencies = [
 [[package]]
 name = "cubecl-macros"
 version = "0.11.0-pre.1"
-source = "git+https://github.com/tracel-ai/cubecl?rev=1d628d7e8fa6ac27c67195b35736de0b63cc2839#1d628d7e8fa6ac27c67195b35736de0b63cc2839"
+source = "git+https://github.com/tracel-ai/cubecl?rev=a30791301897f3dc080fd85df39cc24658c57c84#a30791301897f3dc080fd85df39cc24658c57c84"
 dependencies = [
  "cubecl-common",
  "darling 0.23.0",
@@ -1443,7 +1460,7 @@ dependencies = [
 [[package]]
 name = "cubecl-macros-internal"
 version = "0.11.0-pre.1"
-source = "git+https://github.com/tracel-ai/cubecl?rev=1d628d7e8fa6ac27c67195b35736de0b63cc2839#1d628d7e8fa6ac27c67195b35736de0b63cc2839"
+source = "git+https://github.com/tracel-ai/cubecl?rev=a30791301897f3dc080fd85df39cc24658c57c84#a30791301897f3dc080fd85df39cc24658c57c84"
 dependencies = [
  "darling 0.23.0",
  "proc-macro2",
@@ -1454,7 +1471,7 @@ dependencies = [
 [[package]]
 name = "cubecl-opt"
 version = "0.11.0-pre.1"
-source = "git+https://github.com/tracel-ai/cubecl?rev=1d628d7e8fa6ac27c67195b35736de0b63cc2839#1d628d7e8fa6ac27c67195b35736de0b63cc2839"
+source = "git+https://github.com/tracel-ai/cubecl?rev=a30791301897f3dc080fd85df39cc24658c57c84#a30791301897f3dc080fd85df39cc24658c57c84"
 dependencies = [
  "cubecl-common",
  "cubecl-core",
@@ -1472,7 +1489,7 @@ dependencies = [
 [[package]]
 name = "cubecl-runtime"
 version = "0.11.0-pre.1"
-source = "git+https://github.com/tracel-ai/cubecl?rev=1d628d7e8fa6ac27c67195b35736de0b63cc2839#1d628d7e8fa6ac27c67195b35736de0b63cc2839"
+source = "git+https://github.com/tracel-ai/cubecl?rev=a30791301897f3dc080fd85df39cc24658c57c84#a30791301897f3dc080fd85df39cc24658c57c84"
 dependencies = [
  "ahash",
  "async-channel",
@@ -1503,7 +1520,7 @@ dependencies = [
 [[package]]
 name = "cubecl-std"
 version = "0.11.0-pre.1"
-source = "git+https://github.com/tracel-ai/cubecl?rev=1d628d7e8fa6ac27c67195b35736de0b63cc2839#1d628d7e8fa6ac27c67195b35736de0b63cc2839"
+source = "git+https://github.com/tracel-ai/cubecl?rev=a30791301897f3dc080fd85df39cc24658c57c84#a30791301897f3dc080fd85df39cc24658c57c84"
 dependencies = [
  "cubecl-common",
  "cubecl-core",
@@ -1519,7 +1536,7 @@ dependencies = [
 [[package]]
 name = "cubecl-wgpu"
 version = "0.11.0-pre.1"
-source = "git+https://github.com/tracel-ai/cubecl?rev=1d628d7e8fa6ac27c67195b35736de0b63cc2839#1d628d7e8fa6ac27c67195b35736de0b63cc2839"
+source = "git+https://github.com/tracel-ai/cubecl?rev=a30791301897f3dc080fd85df39cc24658c57c84#a30791301897f3dc080fd85df39cc24658c57c84"
 dependencies = [
  "async-channel",
  "bytemuck",
@@ -1544,7 +1561,7 @@ dependencies = [
 [[package]]
 name = "cubecl-zspace"
 version = "0.11.0-pre.1"
-source = "git+https://github.com/tracel-ai/cubecl?rev=1d628d7e8fa6ac27c67195b35736de0b63cc2839#1d628d7e8fa6ac27c67195b35736de0b63cc2839"
+source = "git+https://github.com/tracel-ai/cubecl?rev=a30791301897f3dc080fd85df39cc24658c57c84#a30791301897f3dc080fd85df39cc24658c57c84"
 dependencies = [
  "derive-new",
  "serde",
@@ -1554,7 +1571,7 @@ dependencies = [
 [[package]]
 name = "cubek"
 version = "0.3.0-pre.1"
-source = "git+https://github.com/tracel-ai/cubek?rev=006a0ed2e9fce76ca1a87fe7687227a0db49e9cd#006a0ed2e9fce76ca1a87fe7687227a0db49e9cd"
+source = "git+https://github.com/tracel-ai/cubek?rev=9cc59e47142699ed9f6e608fc74399a4029b7570#9cc59e47142699ed9f6e608fc74399a4029b7570"
 dependencies = [
  "cubecl",
  "cubek-attention",
@@ -1572,7 +1589,7 @@ dependencies = [
 [[package]]
 name = "cubek-attention"
 version = "0.3.0-pre.1"
-source = "git+https://github.com/tracel-ai/cubek?rev=006a0ed2e9fce76ca1a87fe7687227a0db49e9cd#006a0ed2e9fce76ca1a87fe7687227a0db49e9cd"
+source = "git+https://github.com/tracel-ai/cubek?rev=9cc59e47142699ed9f6e608fc74399a4029b7570#9cc59e47142699ed9f6e608fc74399a4029b7570"
 dependencies = [
  "bytemuck",
  "cubecl",
@@ -1586,7 +1603,7 @@ dependencies = [
 [[package]]
 name = "cubek-convolution"
 version = "0.3.0-pre.1"
-source = "git+https://github.com/tracel-ai/cubek?rev=006a0ed2e9fce76ca1a87fe7687227a0db49e9cd#006a0ed2e9fce76ca1a87fe7687227a0db49e9cd"
+source = "git+https://github.com/tracel-ai/cubek?rev=9cc59e47142699ed9f6e608fc74399a4029b7570#9cc59e47142699ed9f6e608fc74399a4029b7570"
 dependencies = [
  "bytemuck",
  "cubecl",
@@ -1602,7 +1619,7 @@ dependencies = [
 [[package]]
 name = "cubek-fft"
 version = "0.3.0-pre.1"
-source = "git+https://github.com/tracel-ai/cubek?rev=006a0ed2e9fce76ca1a87fe7687227a0db49e9cd#006a0ed2e9fce76ca1a87fe7687227a0db49e9cd"
+source = "git+https://github.com/tracel-ai/cubek?rev=9cc59e47142699ed9f6e608fc74399a4029b7570#9cc59e47142699ed9f6e608fc74399a4029b7570"
 dependencies = [
  "cubecl",
 ]
@@ -1610,23 +1627,33 @@ dependencies = [
 [[package]]
 name = "cubek-interpolate"
 version = "0.3.0-pre.1"
-source = "git+https://github.com/tracel-ai/cubek?rev=006a0ed2e9fce76ca1a87fe7687227a0db49e9cd#006a0ed2e9fce76ca1a87fe7687227a0db49e9cd"
+source = "git+https://github.com/tracel-ai/cubek?rev=9cc59e47142699ed9f6e608fc74399a4029b7570#9cc59e47142699ed9f6e608fc74399a4029b7570"
 dependencies = [
  "cubecl",
  "cubecl-common",
  "half",
+ "serde",
  "thiserror 2.0.18",
+]
+
+[[package]]
+name = "cubek-layout"
+version = "0.3.0-pre.1"
+source = "git+https://github.com/tracel-ai/cubek?rev=9cc59e47142699ed9f6e608fc74399a4029b7570#9cc59e47142699ed9f6e608fc74399a4029b7570"
+dependencies = [
+ "cubecl",
 ]
 
 [[package]]
 name = "cubek-matmul"
 version = "0.3.0-pre.1"
-source = "git+https://github.com/tracel-ai/cubek?rev=006a0ed2e9fce76ca1a87fe7687227a0db49e9cd#006a0ed2e9fce76ca1a87fe7687227a0db49e9cd"
+source = "git+https://github.com/tracel-ai/cubek?rev=9cc59e47142699ed9f6e608fc74399a4029b7570#9cc59e47142699ed9f6e608fc74399a4029b7570"
 dependencies = [
  "bytemuck",
  "cubecl",
  "cubecl-common",
  "cubek-std",
+ "cubek-tile",
  "half",
  "serde",
 ]
@@ -1634,7 +1661,7 @@ dependencies = [
 [[package]]
 name = "cubek-pool"
 version = "0.3.0-pre.1"
-source = "git+https://github.com/tracel-ai/cubek?rev=006a0ed2e9fce76ca1a87fe7687227a0db49e9cd#006a0ed2e9fce76ca1a87fe7687227a0db49e9cd"
+source = "git+https://github.com/tracel-ai/cubek?rev=9cc59e47142699ed9f6e608fc74399a4029b7570#9cc59e47142699ed9f6e608fc74399a4029b7570"
 dependencies = [
  "cubecl",
  "cubecl-common",
@@ -1644,7 +1671,7 @@ dependencies = [
 [[package]]
 name = "cubek-quant"
 version = "0.3.0-pre.1"
-source = "git+https://github.com/tracel-ai/cubek?rev=006a0ed2e9fce76ca1a87fe7687227a0db49e9cd#006a0ed2e9fce76ca1a87fe7687227a0db49e9cd"
+source = "git+https://github.com/tracel-ai/cubek?rev=9cc59e47142699ed9f6e608fc74399a4029b7570#9cc59e47142699ed9f6e608fc74399a4029b7570"
 dependencies = [
  "cubecl",
  "cubecl-common",
@@ -1655,7 +1682,7 @@ dependencies = [
 [[package]]
 name = "cubek-random"
 version = "0.3.0-pre.1"
-source = "git+https://github.com/tracel-ai/cubek?rev=006a0ed2e9fce76ca1a87fe7687227a0db49e9cd#006a0ed2e9fce76ca1a87fe7687227a0db49e9cd"
+source = "git+https://github.com/tracel-ai/cubek?rev=9cc59e47142699ed9f6e608fc74399a4029b7570#9cc59e47142699ed9f6e608fc74399a4029b7570"
 dependencies = [
  "cubecl",
  "cubecl-common",
@@ -1668,9 +1695,10 @@ dependencies = [
 [[package]]
 name = "cubek-reduce"
 version = "0.3.0-pre.1"
-source = "git+https://github.com/tracel-ai/cubek?rev=006a0ed2e9fce76ca1a87fe7687227a0db49e9cd#006a0ed2e9fce76ca1a87fe7687227a0db49e9cd"
+source = "git+https://github.com/tracel-ai/cubek?rev=9cc59e47142699ed9f6e608fc74399a4029b7570#9cc59e47142699ed9f6e608fc74399a4029b7570"
 dependencies = [
  "cubecl",
+ "cubek-layout",
  "cubek-std",
  "half",
  "num-traits",
@@ -1681,11 +1709,24 @@ dependencies = [
 [[package]]
 name = "cubek-std"
 version = "0.3.0-pre.1"
-source = "git+https://github.com/tracel-ai/cubek?rev=006a0ed2e9fce76ca1a87fe7687227a0db49e9cd#006a0ed2e9fce76ca1a87fe7687227a0db49e9cd"
+source = "git+https://github.com/tracel-ai/cubek?rev=9cc59e47142699ed9f6e608fc74399a4029b7570#9cc59e47142699ed9f6e608fc74399a4029b7570"
 dependencies = [
  "cubecl",
  "cubecl-common",
  "half",
+]
+
+[[package]]
+name = "cubek-tile"
+version = "0.3.0-pre.1"
+source = "git+https://github.com/tracel-ai/cubek?rev=9cc59e47142699ed9f6e608fc74399a4029b7570#9cc59e47142699ed9f6e608fc74399a4029b7570"
+dependencies = [
+ "bytemuck",
+ "cubecl",
+ "cubecl-common",
+ "cubek-layout",
+ "half",
+ "serde",
 ]
 
 [[package]]
@@ -3878,6 +3919,10 @@ name = "once_cell"
 version = "1.21.4"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "9f7c3e4beb33f85d45ae3e3a1792185706c8e16d043238c593331cc7cd313b50"
+dependencies = [
+ "critical-section",
+ "portable-atomic",
+]
 
 [[package]]
 name = "once_cell_polyfill"
@@ -4059,6 +4104,7 @@ version = "1.13.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "c33a9471896f1c69cecef8d20cbe2f7accd12527ce60845ff44c153bb2a21b49"
 dependencies = [
+ "critical-section",
  "serde",
 ]
 
@@ -6158,12 +6204,6 @@ name = "untrusted"
 version = "0.9.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "8ecb6da28b8a351d773b68d5825ac39017e680750f980f3a1a85cd8dd28a47c1"
-
-[[package]]
-name = "unty"
-version = "0.0.4"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "6d49784317cd0d1ee7ec5c716dd598ec5b4483ea832a2dced265471cc0f690ae"
 
 [[package]]
 name = "ureq"

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -301,7 +301,6 @@ checksum = "72f5acc6cb2ba439de613abc23857ec3d78374d8ed5ac84e9d11336e87da8649"
 [[package]]
 name = "burn"
 version = "0.22.0-pre.1"
-source = "git+https://github.com/tracel-ai/burn?rev=862ef266ade864d6fc48df3687e9f8b911c7d05e#862ef266ade864d6fc48df3687e9f8b911c7d05e"
 dependencies = [
  "burn-autodiff",
  "burn-core",
@@ -315,7 +314,6 @@ dependencies = [
 [[package]]
 name = "burn-autodiff"
 version = "0.22.0-pre.1"
-source = "git+https://github.com/tracel-ai/burn?rev=862ef266ade864d6fc48df3687e9f8b911c7d05e#862ef266ade864d6fc48df3687e9f8b911c7d05e"
 dependencies = [
  "burn-backend",
  "burn-std",
@@ -332,7 +330,6 @@ dependencies = [
 [[package]]
 name = "burn-backend"
 version = "0.22.0-pre.1"
-source = "git+https://github.com/tracel-ai/burn?rev=862ef266ade864d6fc48df3687e9f8b911c7d05e#862ef266ade864d6fc48df3687e9f8b911c7d05e"
 dependencies = [
  "burn-std",
  "bytemuck",
@@ -352,7 +349,6 @@ dependencies = [
 [[package]]
 name = "burn-backend-extension"
 version = "0.22.0-pre.1"
-source = "git+https://github.com/tracel-ai/burn?rev=862ef266ade864d6fc48df3687e9f8b911c7d05e#862ef266ade864d6fc48df3687e9f8b911c7d05e"
 dependencies = [
  "proc-macro2",
  "quote",
@@ -362,7 +358,6 @@ dependencies = [
 [[package]]
 name = "burn-core"
 version = "0.22.0-pre.1"
-source = "git+https://github.com/tracel-ai/burn?rev=862ef266ade864d6fc48df3687e9f8b911c7d05e#862ef266ade864d6fc48df3687e9f8b911c7d05e"
 dependencies = [
  "ahash",
  "burn-backend",
@@ -389,7 +384,6 @@ dependencies = [
 [[package]]
 name = "burn-cpu"
 version = "0.22.0-pre.1"
-source = "git+https://github.com/tracel-ai/burn?rev=862ef266ade864d6fc48df3687e9f8b911c7d05e#862ef266ade864d6fc48df3687e9f8b911c7d05e"
 dependencies = [
  "burn-backend",
  "burn-cubecl",
@@ -399,7 +393,6 @@ dependencies = [
 [[package]]
 name = "burn-cubecl"
 version = "0.22.0-pre.1"
-source = "git+https://github.com/tracel-ai/burn?rev=862ef266ade864d6fc48df3687e9f8b911c7d05e#862ef266ade864d6fc48df3687e9f8b911c7d05e"
 dependencies = [
  "burn-backend",
  "burn-cubecl-fusion",
@@ -418,7 +411,6 @@ dependencies = [
 [[package]]
 name = "burn-cubecl-fusion"
 version = "0.22.0-pre.1"
-source = "git+https://github.com/tracel-ai/burn?rev=862ef266ade864d6fc48df3687e9f8b911c7d05e#862ef266ade864d6fc48df3687e9f8b911c7d05e"
 dependencies = [
  "burn-backend",
  "burn-fusion",
@@ -435,7 +427,6 @@ dependencies = [
 [[package]]
 name = "burn-cuda"
 version = "0.22.0-pre.1"
-source = "git+https://github.com/tracel-ai/burn?rev=862ef266ade864d6fc48df3687e9f8b911c7d05e#862ef266ade864d6fc48df3687e9f8b911c7d05e"
 dependencies = [
  "burn-backend",
  "burn-cubecl",
@@ -445,7 +436,6 @@ dependencies = [
 [[package]]
 name = "burn-dataset"
 version = "0.22.0-pre.1"
-source = "git+https://github.com/tracel-ai/burn?rev=862ef266ade864d6fc48df3687e9f8b911c7d05e#862ef266ade864d6fc48df3687e9f8b911c7d05e"
 dependencies = [
  "csv",
  "derive-new",
@@ -463,7 +453,6 @@ dependencies = [
 [[package]]
 name = "burn-derive"
 version = "0.22.0-pre.1"
-source = "git+https://github.com/tracel-ai/burn?rev=862ef266ade864d6fc48df3687e9f8b911c7d05e#862ef266ade864d6fc48df3687e9f8b911c7d05e"
 dependencies = [
  "derive-new",
  "proc-macro2",
@@ -474,7 +463,6 @@ dependencies = [
 [[package]]
 name = "burn-dispatch"
 version = "0.22.0-pre.1"
-source = "git+https://github.com/tracel-ai/burn?rev=862ef266ade864d6fc48df3687e9f8b911c7d05e#862ef266ade864d6fc48df3687e9f8b911c7d05e"
 dependencies = [
  "burn-autodiff",
  "burn-backend",
@@ -491,7 +479,6 @@ dependencies = [
 [[package]]
 name = "burn-flex"
 version = "0.22.0-pre.1"
-source = "git+https://github.com/tracel-ai/burn?rev=862ef266ade864d6fc48df3687e9f8b911c7d05e#862ef266ade864d6fc48df3687e9f8b911c7d05e"
 dependencies = [
  "aligned-vec",
  "burn-backend",
@@ -512,7 +499,6 @@ dependencies = [
 [[package]]
 name = "burn-fusion"
 version = "0.22.0-pre.1"
-source = "git+https://github.com/tracel-ai/burn?rev=862ef266ade864d6fc48df3687e9f8b911c7d05e#862ef266ade864d6fc48df3687e9f8b911c7d05e"
 dependencies = [
  "burn-backend",
  "burn-ir",
@@ -529,7 +515,6 @@ dependencies = [
 [[package]]
 name = "burn-ir"
 version = "0.22.0-pre.1"
-source = "git+https://github.com/tracel-ai/burn?rev=862ef266ade864d6fc48df3687e9f8b911c7d05e#862ef266ade864d6fc48df3687e9f8b911c7d05e"
 dependencies = [
  "burn-backend",
  "hashbrown 0.16.1",
@@ -539,7 +524,6 @@ dependencies = [
 [[package]]
 name = "burn-ndarray"
 version = "0.22.0-pre.1"
-source = "git+https://github.com/tracel-ai/burn?rev=862ef266ade864d6fc48df3687e9f8b911c7d05e#862ef266ade864d6fc48df3687e9f8b911c7d05e"
 dependencies = [
  "atomic_float",
  "burn-autodiff",
@@ -561,7 +545,6 @@ dependencies = [
 [[package]]
 name = "burn-nn"
 version = "0.22.0-pre.1"
-source = "git+https://github.com/tracel-ai/burn?rev=862ef266ade864d6fc48df3687e9f8b911c7d05e#862ef266ade864d6fc48df3687e9f8b911c7d05e"
 dependencies = [
  "burn-core",
  "num-traits",
@@ -570,7 +553,6 @@ dependencies = [
 [[package]]
 name = "burn-optim"
 version = "0.22.0-pre.1"
-source = "git+https://github.com/tracel-ai/burn?rev=862ef266ade864d6fc48df3687e9f8b911c7d05e#862ef266ade864d6fc48df3687e9f8b911c7d05e"
 dependencies = [
  "burn-core",
  "burn-derive",
@@ -585,7 +567,6 @@ dependencies = [
 [[package]]
 name = "burn-pack"
 version = "0.22.0-pre.1"
-source = "git+https://github.com/tracel-ai/burn?rev=862ef266ade864d6fc48df3687e9f8b911c7d05e#862ef266ade864d6fc48df3687e9f8b911c7d05e"
 dependencies = [
  "burn-std",
  "byteorder",
@@ -596,7 +577,6 @@ dependencies = [
 [[package]]
 name = "burn-rocm"
 version = "0.22.0-pre.1"
-source = "git+https://github.com/tracel-ai/burn?rev=862ef266ade864d6fc48df3687e9f8b911c7d05e#862ef266ade864d6fc48df3687e9f8b911c7d05e"
 dependencies = [
  "burn-backend",
  "burn-cubecl",
@@ -606,7 +586,6 @@ dependencies = [
 [[package]]
 name = "burn-std"
 version = "0.22.0-pre.1"
-source = "git+https://github.com/tracel-ai/burn?rev=862ef266ade864d6fc48df3687e9f8b911c7d05e#862ef266ade864d6fc48df3687e9f8b911c7d05e"
 dependencies = [
  "ahash",
  "bytemuck",
@@ -632,7 +611,6 @@ dependencies = [
 [[package]]
 name = "burn-tch"
 version = "0.22.0-pre.1"
-source = "git+https://github.com/tracel-ai/burn?rev=862ef266ade864d6fc48df3687e9f8b911c7d05e#862ef266ade864d6fc48df3687e9f8b911c7d05e"
 dependencies = [
  "burn-backend",
  "cc",
@@ -645,7 +623,6 @@ dependencies = [
 [[package]]
 name = "burn-tensor"
 version = "0.22.0-pre.1"
-source = "git+https://github.com/tracel-ai/burn?rev=862ef266ade864d6fc48df3687e9f8b911c7d05e#862ef266ade864d6fc48df3687e9f8b911c7d05e"
 dependencies = [
  "burn-backend",
  "burn-dispatch",
@@ -659,7 +636,6 @@ dependencies = [
 [[package]]
 name = "burn-train"
 version = "0.22.0-pre.1"
-source = "git+https://github.com/tracel-ai/burn?rev=862ef266ade864d6fc48df3687e9f8b911c7d05e#862ef266ade864d6fc48df3687e9f8b911c7d05e"
 dependencies = [
  "async-channel",
  "burn-core",
@@ -680,7 +656,6 @@ dependencies = [
 [[package]]
 name = "burn-wgpu"
 version = "0.22.0-pre.1"
-source = "git+https://github.com/tracel-ai/burn?rev=862ef266ade864d6fc48df3687e9f8b911c7d05e#862ef266ade864d6fc48df3687e9f8b911c7d05e"
 dependencies = [
  "burn-backend",
  "burn-cubecl",
@@ -715,9 +690,9 @@ checksum = "1fd0f2584146f6f2ef48085050886acf353beff7305ebd1ae69500e27c67f64b"
 
 [[package]]
 name = "bytes"
-version = "1.11.1"
+version = "1.12.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "1e748733b7cbc798e1434b6ac524f0c1ff2ab456fe201501e6497c8417a4fc33"
+checksum = "8ae3f5d315924270530207e2a68396c3cc547f6dca3fbdca317cfb1a51edb593"
 dependencies = [
  "portable-atomic",
 ]
@@ -762,9 +737,9 @@ dependencies = [
 
 [[package]]
 name = "cc"
-version = "1.2.64"
+version = "1.2.65"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "dad887fd958be91b5098c0248def011f4523ab786cd411be668777e55063501f"
+checksum = "e228eec9be7c17ccb640b59b36a5cd805ea2a564a4c5e162c2f659fea30d3b96"
 dependencies = [
  "find-msvc-tools",
  "jobserver",
@@ -1247,7 +1222,7 @@ dependencies = [
 [[package]]
 name = "cubecl"
 version = "0.11.0-pre.1"
-source = "git+https://github.com/tracel-ai/cubecl?rev=a30791301897f3dc080fd85df39cc24658c57c84#a30791301897f3dc080fd85df39cc24658c57c84"
+source = "git+https://github.com/tracel-ai/cubecl?rev=945cce851dd7d0614e127fbf9a63e767c04ebdda#945cce851dd7d0614e127fbf9a63e767c04ebdda"
 dependencies = [
  "cubecl-core",
  "cubecl-cpu",
@@ -1263,7 +1238,7 @@ dependencies = [
 [[package]]
 name = "cubecl-common"
 version = "0.11.0-pre.1"
-source = "git+https://github.com/tracel-ai/cubecl?rev=a30791301897f3dc080fd85df39cc24658c57c84#a30791301897f3dc080fd85df39cc24658c57c84"
+source = "git+https://github.com/tracel-ai/cubecl?rev=945cce851dd7d0614e127fbf9a63e767c04ebdda#945cce851dd7d0614e127fbf9a63e767c04ebdda"
 dependencies = [
  "backtrace",
  "bytemuck",
@@ -1304,7 +1279,7 @@ dependencies = [
 [[package]]
 name = "cubecl-core"
 version = "0.11.0-pre.1"
-source = "git+https://github.com/tracel-ai/cubecl?rev=a30791301897f3dc080fd85df39cc24658c57c84#a30791301897f3dc080fd85df39cc24658c57c84"
+source = "git+https://github.com/tracel-ai/cubecl?rev=945cce851dd7d0614e127fbf9a63e767c04ebdda#945cce851dd7d0614e127fbf9a63e767c04ebdda"
 dependencies = [
  "bitflags",
  "bytemuck",
@@ -1333,7 +1308,7 @@ dependencies = [
 [[package]]
 name = "cubecl-cpp"
 version = "0.11.0-pre.1"
-source = "git+https://github.com/tracel-ai/cubecl?rev=a30791301897f3dc080fd85df39cc24658c57c84#a30791301897f3dc080fd85df39cc24658c57c84"
+source = "git+https://github.com/tracel-ai/cubecl?rev=945cce851dd7d0614e127fbf9a63e767c04ebdda#945cce851dd7d0614e127fbf9a63e767c04ebdda"
 dependencies = [
  "bytemuck",
  "cubecl-common",
@@ -1349,7 +1324,7 @@ dependencies = [
 [[package]]
 name = "cubecl-cpu"
 version = "0.11.0-pre.1"
-source = "git+https://github.com/tracel-ai/cubecl?rev=a30791301897f3dc080fd85df39cc24658c57c84#a30791301897f3dc080fd85df39cc24658c57c84"
+source = "git+https://github.com/tracel-ai/cubecl?rev=945cce851dd7d0614e127fbf9a63e767c04ebdda#945cce851dd7d0614e127fbf9a63e767c04ebdda"
 dependencies = [
  "bytemuck",
  "cubecl-common",
@@ -1372,7 +1347,7 @@ dependencies = [
 [[package]]
 name = "cubecl-cuda"
 version = "0.11.0-pre.1"
-source = "git+https://github.com/tracel-ai/cubecl?rev=a30791301897f3dc080fd85df39cc24658c57c84#a30791301897f3dc080fd85df39cc24658c57c84"
+source = "git+https://github.com/tracel-ai/cubecl?rev=945cce851dd7d0614e127fbf9a63e767c04ebdda#945cce851dd7d0614e127fbf9a63e767c04ebdda"
 dependencies = [
  "bytemuck",
  "cubecl-common",
@@ -1390,7 +1365,7 @@ dependencies = [
 [[package]]
 name = "cubecl-hip"
 version = "0.11.0-pre.1"
-source = "git+https://github.com/tracel-ai/cubecl?rev=a30791301897f3dc080fd85df39cc24658c57c84#a30791301897f3dc080fd85df39cc24658c57c84"
+source = "git+https://github.com/tracel-ai/cubecl?rev=945cce851dd7d0614e127fbf9a63e767c04ebdda#945cce851dd7d0614e127fbf9a63e767c04ebdda"
 dependencies = [
  "bytemuck",
  "cubecl-common",
@@ -1419,7 +1394,7 @@ dependencies = [
 [[package]]
 name = "cubecl-ir"
 version = "0.11.0-pre.1"
-source = "git+https://github.com/tracel-ai/cubecl?rev=a30791301897f3dc080fd85df39cc24658c57c84#a30791301897f3dc080fd85df39cc24658c57c84"
+source = "git+https://github.com/tracel-ai/cubecl?rev=945cce851dd7d0614e127fbf9a63e767c04ebdda#945cce851dd7d0614e127fbf9a63e767c04ebdda"
 dependencies = [
  "bumpalo",
  "cubecl-common",
@@ -1443,7 +1418,7 @@ dependencies = [
 [[package]]
 name = "cubecl-macros"
 version = "0.11.0-pre.1"
-source = "git+https://github.com/tracel-ai/cubecl?rev=a30791301897f3dc080fd85df39cc24658c57c84#a30791301897f3dc080fd85df39cc24658c57c84"
+source = "git+https://github.com/tracel-ai/cubecl?rev=945cce851dd7d0614e127fbf9a63e767c04ebdda#945cce851dd7d0614e127fbf9a63e767c04ebdda"
 dependencies = [
  "cubecl-common",
  "darling 0.23.0",
@@ -1460,7 +1435,7 @@ dependencies = [
 [[package]]
 name = "cubecl-macros-internal"
 version = "0.11.0-pre.1"
-source = "git+https://github.com/tracel-ai/cubecl?rev=a30791301897f3dc080fd85df39cc24658c57c84#a30791301897f3dc080fd85df39cc24658c57c84"
+source = "git+https://github.com/tracel-ai/cubecl?rev=945cce851dd7d0614e127fbf9a63e767c04ebdda#945cce851dd7d0614e127fbf9a63e767c04ebdda"
 dependencies = [
  "darling 0.23.0",
  "proc-macro2",
@@ -1471,7 +1446,7 @@ dependencies = [
 [[package]]
 name = "cubecl-opt"
 version = "0.11.0-pre.1"
-source = "git+https://github.com/tracel-ai/cubecl?rev=a30791301897f3dc080fd85df39cc24658c57c84#a30791301897f3dc080fd85df39cc24658c57c84"
+source = "git+https://github.com/tracel-ai/cubecl?rev=945cce851dd7d0614e127fbf9a63e767c04ebdda#945cce851dd7d0614e127fbf9a63e767c04ebdda"
 dependencies = [
  "cubecl-common",
  "cubecl-core",
@@ -1489,7 +1464,7 @@ dependencies = [
 [[package]]
 name = "cubecl-runtime"
 version = "0.11.0-pre.1"
-source = "git+https://github.com/tracel-ai/cubecl?rev=a30791301897f3dc080fd85df39cc24658c57c84#a30791301897f3dc080fd85df39cc24658c57c84"
+source = "git+https://github.com/tracel-ai/cubecl?rev=945cce851dd7d0614e127fbf9a63e767c04ebdda#945cce851dd7d0614e127fbf9a63e767c04ebdda"
 dependencies = [
  "ahash",
  "async-channel",
@@ -1520,7 +1495,7 @@ dependencies = [
 [[package]]
 name = "cubecl-std"
 version = "0.11.0-pre.1"
-source = "git+https://github.com/tracel-ai/cubecl?rev=a30791301897f3dc080fd85df39cc24658c57c84#a30791301897f3dc080fd85df39cc24658c57c84"
+source = "git+https://github.com/tracel-ai/cubecl?rev=945cce851dd7d0614e127fbf9a63e767c04ebdda#945cce851dd7d0614e127fbf9a63e767c04ebdda"
 dependencies = [
  "cubecl-common",
  "cubecl-core",
@@ -1536,7 +1511,7 @@ dependencies = [
 [[package]]
 name = "cubecl-wgpu"
 version = "0.11.0-pre.1"
-source = "git+https://github.com/tracel-ai/cubecl?rev=a30791301897f3dc080fd85df39cc24658c57c84#a30791301897f3dc080fd85df39cc24658c57c84"
+source = "git+https://github.com/tracel-ai/cubecl?rev=945cce851dd7d0614e127fbf9a63e767c04ebdda#945cce851dd7d0614e127fbf9a63e767c04ebdda"
 dependencies = [
  "async-channel",
  "bytemuck",
@@ -1561,7 +1536,7 @@ dependencies = [
 [[package]]
 name = "cubecl-zspace"
 version = "0.11.0-pre.1"
-source = "git+https://github.com/tracel-ai/cubecl?rev=a30791301897f3dc080fd85df39cc24658c57c84#a30791301897f3dc080fd85df39cc24658c57c84"
+source = "git+https://github.com/tracel-ai/cubecl?rev=945cce851dd7d0614e127fbf9a63e767c04ebdda#945cce851dd7d0614e127fbf9a63e767c04ebdda"
 dependencies = [
  "derive-new",
  "serde",
@@ -1571,7 +1546,7 @@ dependencies = [
 [[package]]
 name = "cubek"
 version = "0.3.0-pre.1"
-source = "git+https://github.com/tracel-ai/cubek?rev=9cc59e47142699ed9f6e608fc74399a4029b7570#9cc59e47142699ed9f6e608fc74399a4029b7570"
+source = "git+https://github.com/tracel-ai/cubek?rev=fb2ddf234cb71e4012c27a3f82291932f15ca0a0#fb2ddf234cb71e4012c27a3f82291932f15ca0a0"
 dependencies = [
  "cubecl",
  "cubek-attention",
@@ -1589,7 +1564,7 @@ dependencies = [
 [[package]]
 name = "cubek-attention"
 version = "0.3.0-pre.1"
-source = "git+https://github.com/tracel-ai/cubek?rev=9cc59e47142699ed9f6e608fc74399a4029b7570#9cc59e47142699ed9f6e608fc74399a4029b7570"
+source = "git+https://github.com/tracel-ai/cubek?rev=fb2ddf234cb71e4012c27a3f82291932f15ca0a0#fb2ddf234cb71e4012c27a3f82291932f15ca0a0"
 dependencies = [
  "bytemuck",
  "cubecl",
@@ -1603,7 +1578,7 @@ dependencies = [
 [[package]]
 name = "cubek-convolution"
 version = "0.3.0-pre.1"
-source = "git+https://github.com/tracel-ai/cubek?rev=9cc59e47142699ed9f6e608fc74399a4029b7570#9cc59e47142699ed9f6e608fc74399a4029b7570"
+source = "git+https://github.com/tracel-ai/cubek?rev=fb2ddf234cb71e4012c27a3f82291932f15ca0a0#fb2ddf234cb71e4012c27a3f82291932f15ca0a0"
 dependencies = [
  "bytemuck",
  "cubecl",
@@ -1619,7 +1594,7 @@ dependencies = [
 [[package]]
 name = "cubek-fft"
 version = "0.3.0-pre.1"
-source = "git+https://github.com/tracel-ai/cubek?rev=9cc59e47142699ed9f6e608fc74399a4029b7570#9cc59e47142699ed9f6e608fc74399a4029b7570"
+source = "git+https://github.com/tracel-ai/cubek?rev=fb2ddf234cb71e4012c27a3f82291932f15ca0a0#fb2ddf234cb71e4012c27a3f82291932f15ca0a0"
 dependencies = [
  "cubecl",
 ]
@@ -1627,7 +1602,7 @@ dependencies = [
 [[package]]
 name = "cubek-interpolate"
 version = "0.3.0-pre.1"
-source = "git+https://github.com/tracel-ai/cubek?rev=9cc59e47142699ed9f6e608fc74399a4029b7570#9cc59e47142699ed9f6e608fc74399a4029b7570"
+source = "git+https://github.com/tracel-ai/cubek?rev=fb2ddf234cb71e4012c27a3f82291932f15ca0a0#fb2ddf234cb71e4012c27a3f82291932f15ca0a0"
 dependencies = [
  "cubecl",
  "cubecl-common",
@@ -1639,7 +1614,7 @@ dependencies = [
 [[package]]
 name = "cubek-layout"
 version = "0.3.0-pre.1"
-source = "git+https://github.com/tracel-ai/cubek?rev=9cc59e47142699ed9f6e608fc74399a4029b7570#9cc59e47142699ed9f6e608fc74399a4029b7570"
+source = "git+https://github.com/tracel-ai/cubek?rev=fb2ddf234cb71e4012c27a3f82291932f15ca0a0#fb2ddf234cb71e4012c27a3f82291932f15ca0a0"
 dependencies = [
  "cubecl",
 ]
@@ -1647,7 +1622,7 @@ dependencies = [
 [[package]]
 name = "cubek-matmul"
 version = "0.3.0-pre.1"
-source = "git+https://github.com/tracel-ai/cubek?rev=9cc59e47142699ed9f6e608fc74399a4029b7570#9cc59e47142699ed9f6e608fc74399a4029b7570"
+source = "git+https://github.com/tracel-ai/cubek?rev=fb2ddf234cb71e4012c27a3f82291932f15ca0a0#fb2ddf234cb71e4012c27a3f82291932f15ca0a0"
 dependencies = [
  "bytemuck",
  "cubecl",
@@ -1661,7 +1636,7 @@ dependencies = [
 [[package]]
 name = "cubek-pool"
 version = "0.3.0-pre.1"
-source = "git+https://github.com/tracel-ai/cubek?rev=9cc59e47142699ed9f6e608fc74399a4029b7570#9cc59e47142699ed9f6e608fc74399a4029b7570"
+source = "git+https://github.com/tracel-ai/cubek?rev=fb2ddf234cb71e4012c27a3f82291932f15ca0a0#fb2ddf234cb71e4012c27a3f82291932f15ca0a0"
 dependencies = [
  "cubecl",
  "cubecl-common",
@@ -1671,10 +1646,11 @@ dependencies = [
 [[package]]
 name = "cubek-quant"
 version = "0.3.0-pre.1"
-source = "git+https://github.com/tracel-ai/cubek?rev=9cc59e47142699ed9f6e608fc74399a4029b7570#9cc59e47142699ed9f6e608fc74399a4029b7570"
+source = "git+https://github.com/tracel-ai/cubek?rev=fb2ddf234cb71e4012c27a3f82291932f15ca0a0#fb2ddf234cb71e4012c27a3f82291932f15ca0a0"
 dependencies = [
  "cubecl",
  "cubecl-common",
+ "cubek-tile",
  "half",
  "serde",
 ]
@@ -1682,7 +1658,7 @@ dependencies = [
 [[package]]
 name = "cubek-random"
 version = "0.3.0-pre.1"
-source = "git+https://github.com/tracel-ai/cubek?rev=9cc59e47142699ed9f6e608fc74399a4029b7570#9cc59e47142699ed9f6e608fc74399a4029b7570"
+source = "git+https://github.com/tracel-ai/cubek?rev=fb2ddf234cb71e4012c27a3f82291932f15ca0a0#fb2ddf234cb71e4012c27a3f82291932f15ca0a0"
 dependencies = [
  "cubecl",
  "cubecl-common",
@@ -1695,7 +1671,7 @@ dependencies = [
 [[package]]
 name = "cubek-reduce"
 version = "0.3.0-pre.1"
-source = "git+https://github.com/tracel-ai/cubek?rev=9cc59e47142699ed9f6e608fc74399a4029b7570#9cc59e47142699ed9f6e608fc74399a4029b7570"
+source = "git+https://github.com/tracel-ai/cubek?rev=fb2ddf234cb71e4012c27a3f82291932f15ca0a0#fb2ddf234cb71e4012c27a3f82291932f15ca0a0"
 dependencies = [
  "cubecl",
  "cubek-layout",
@@ -1709,7 +1685,7 @@ dependencies = [
 [[package]]
 name = "cubek-std"
 version = "0.3.0-pre.1"
-source = "git+https://github.com/tracel-ai/cubek?rev=9cc59e47142699ed9f6e608fc74399a4029b7570#9cc59e47142699ed9f6e608fc74399a4029b7570"
+source = "git+https://github.com/tracel-ai/cubek?rev=fb2ddf234cb71e4012c27a3f82291932f15ca0a0#fb2ddf234cb71e4012c27a3f82291932f15ca0a0"
 dependencies = [
  "cubecl",
  "cubecl-common",
@@ -1719,7 +1695,7 @@ dependencies = [
 [[package]]
 name = "cubek-tile"
 version = "0.3.0-pre.1"
-source = "git+https://github.com/tracel-ai/cubek?rev=9cc59e47142699ed9f6e608fc74399a4029b7570#9cc59e47142699ed9f6e608fc74399a4029b7570"
+source = "git+https://github.com/tracel-ai/cubek?rev=fb2ddf234cb71e4012c27a3f82291932f15ca0a0#fb2ddf234cb71e4012c27a3f82291932f15ca0a0"
 dependencies = [
  "bytemuck",
  "cubecl",
@@ -1731,9 +1707,9 @@ dependencies = [
 
 [[package]]
 name = "cudarc"
-version = "0.19.7"
+version = "0.19.8"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "1cea5f10a99e025c1b44ae2354c2d8326b25ddbd0baf76bde8e55cfd4018a2cc"
+checksum = "42310153e06cf4cd532901f7096beb27504d681736a29ee90728ae4e2d93b2a8"
 dependencies = [
  "libloading 0.9.0",
 ]
@@ -1859,7 +1835,6 @@ version = "0.5.8"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "7cd812cc2bc1d69d4764bd80df88b4317eaef9e773c75226407d9bc0876b211c"
 dependencies = [
- "powerfmt",
  "serde_core",
 ]
 
@@ -2623,16 +2598,14 @@ dependencies = [
 
 [[package]]
 name = "getrandom"
-version = "0.4.2"
+version = "0.4.3"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "0de51e6874e94e7bf76d726fc5d13ba782deca734ff60d5bb2fb2607c7406555"
+checksum = "300e883d756b2e4ec94e02791f39b04b522276138852cfc41d9fb7e904106099"
 dependencies = [
  "cfg-if",
  "libc",
  "r-efi 6.0.0",
  "rand_core 0.10.1",
- "wasip2",
- "wasip3",
 ]
 
 [[package]]
@@ -2715,9 +2688,9 @@ dependencies = [
 
 [[package]]
 name = "h2"
-version = "0.4.14"
+version = "0.4.15"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "171fefbc92fe4a4de27e0698d6a5b392d6a0e333506bc49133760b3bcf948733"
+checksum = "6cb093c84e8bd9b188d4c4a8cb6579fc016968d14c99882163cd3ff402a4f155"
 dependencies = [
  "atomic-waker",
  "bytes",
@@ -2913,7 +2886,7 @@ dependencies = [
  "tokio",
  "tokio-rustls",
  "tower-service",
- "webpki-roots 1.0.7",
+ "webpki-roots 1.0.8",
 ]
 
 [[package]]
@@ -3046,12 +3019,6 @@ dependencies = [
  "zerotrie",
  "zerovec",
 ]
-
-[[package]]
-name = "id-arena"
-version = "2.3.0"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "3d3067d79b975e8844ca9eb072e16b31c3c1c36928edf9c6789548c524d0d954"
 
 [[package]]
 name = "ident_case"
@@ -3263,9 +3230,9 @@ dependencies = [
 
 [[package]]
 name = "js-sys"
-version = "0.3.100"
+version = "0.3.102"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "f2025f20d7a4fa7785846e7b63d10a76d3f1cee98ee5cb79ea59703f95e42162"
+checksum = "03d04c30968dffe80775bd4d7fb676131cd04a1fb46d2686dbffbaec2d9dfd31"
 dependencies = [
  "cfg-if",
  "futures-util",
@@ -3316,12 +3283,6 @@ name = "lazy_static"
 version = "1.5.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "bbd2bcb4c963f2ddae06a2efc7e9f3591312473c50c6685e1f298068316e66fe"
-
-[[package]]
-name = "leb128fmt"
-version = "0.1.0"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "09edd9e8b54e49e587e4f6295a7d29c3ea94d469cb40ab8ca70b288248a81db2"
 
 [[package]]
 name = "libbz2-rs-sys"
@@ -3938,9 +3899,9 @@ checksum = "cfe21416a02c693fb9f980befcb230ecc70b0b3d1cc4abf88b9675c4c1457f0c"
 
 [[package]]
 name = "openssl"
-version = "0.10.80"
+version = "0.10.81"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "a45fa2aa886c42762255da344f0a0d313e254066c46aad76f300c3d3da62d967"
+checksum = "77823a27f0babb03091cb9ed9ef80af3b39dbc82f97e8fa530374b7dafd87a45"
 dependencies = [
  "bitflags",
  "cfg-if",
@@ -3969,9 +3930,9 @@ checksum = "7c87def4c32ab89d880effc9e097653c8da5d6ef28e6b539d313baaacfbafcbe"
 
 [[package]]
 name = "openssl-sys"
-version = "0.9.116"
+version = "0.9.117"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "f28a22dc7140cda5f096e5e7724a6962ca81a7f8bfd2979f9b18c11af56318c4"
+checksum = "b47e7e6bb2c38cd930d25a23b40fa52e068c10e85f3e03a7f5ba5aaca5713695"
 dependencies = [
  "cc",
  "libc",
@@ -4340,7 +4301,7 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "d2e8e8bcc7961af1fdac401278c6a831614941f6164ee3bf4ce61b7edb162207"
 dependencies = [
  "chacha20",
- "getrandom 0.4.2",
+ "getrandom 0.4.3",
  "rand_core 0.10.1",
 ]
 
@@ -4600,7 +4561,7 @@ dependencies = [
  "wasm-bindgen",
  "wasm-bindgen-futures",
  "web-sys",
- "webpki-roots 1.0.7",
+ "webpki-roots 1.0.8",
 ]
 
 [[package]]
@@ -5283,9 +5244,9 @@ checksum = "a7973cce6668464ea31f176d85b13c7ab3bba2cb3b77a2ed26abd7801688010a"
 
 [[package]]
 name = "syn"
-version = "2.0.117"
+version = "2.0.118"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "e665b8803e7b1d2a727f4023456bbbbe74da67099c585258af0ad9c5013b9b99"
+checksum = "1b9ae57f904213ebb649ce6895b8a66c66f0203b9319718f69a5612a065b1422"
 dependencies = [
  "proc-macro2",
  "quote",
@@ -5409,7 +5370,7 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "32497e9a4c7b38532efcdebeef879707aa9f794296a4f0244f6f69e9bc8574bd"
 dependencies = [
  "fastrand",
- "getrandom 0.4.2",
+ "getrandom 0.4.3",
  "once_cell",
  "rustix",
  "windows-sys 0.61.2",
@@ -5486,12 +5447,11 @@ dependencies = [
 
 [[package]]
 name = "time"
-version = "0.3.47"
+version = "0.3.49"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "743bd48c283afc0388f9b8827b976905fb217ad9e647fae3a379a9283c4def2c"
+checksum = "711a53c2d47bbd818258c498c8dbfe186a2526c631495cfe7e078567f86b8469"
 dependencies = [
  "deranged",
- "itoa",
  "num-conv",
  "powerfmt",
  "serde_core",
@@ -5501,15 +5461,15 @@ dependencies = [
 
 [[package]]
 name = "time-core"
-version = "0.1.8"
+version = "0.1.9"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "7694e1cfe791f8d31026952abf09c69ca6f6fa4e1a1229e18988f06a04a12dca"
+checksum = "9e1c906769ad99c88eaa54e728060edef082f8e358ff32030cb7c7d315e81109"
 
 [[package]]
 name = "time-macros"
-version = "0.2.27"
+version = "0.2.29"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "2e70e4c5a0e0a8a4823ad65dfe1a6930e4f4d756dcd9dd7939022b5e8c501215"
+checksum = "71c652a3727a9cbb9a02f707f530b618ce00d0ccd762009c8c23bd191df3c17d"
 dependencies = [
  "num-conv",
  "time-core",
@@ -6240,7 +6200,7 @@ dependencies = [
  "serde_json",
  "ureq-proto",
  "utf8-zero",
- "webpki-roots 1.0.7",
+ "webpki-roots 1.0.8",
 ]
 
 [[package]]
@@ -6377,23 +6337,14 @@ version = "1.0.4+wasi-0.2.12"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "b67efb37e106e55ce722a510d6b5f9c17f083e5fc79afc2badeb12cc313d9487"
 dependencies = [
- "wit-bindgen 0.57.1",
-]
-
-[[package]]
-name = "wasip3"
-version = "0.4.0+wasi-0.3.0-rc-2026-01-06"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "5428f8bf88ea5ddc08faddef2ac4a67e390b88186c703ce6dbd955e1c145aca5"
-dependencies = [
- "wit-bindgen 0.51.0",
+ "wit-bindgen",
 ]
 
 [[package]]
 name = "wasm-bindgen"
-version = "0.2.123"
+version = "0.2.125"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "a254a4b10c19a76f09a27640e7ffbf9bc30bf67e16a3bf28aaefa4920fe81563"
+checksum = "8ddb3f79143bced6de84270411622a2699cee572fc0875aeaf1e7867cf9fca1a"
 dependencies = [
  "cfg-if",
  "once_cell",
@@ -6404,9 +6355,9 @@ dependencies = [
 
 [[package]]
 name = "wasm-bindgen-futures"
-version = "0.4.73"
+version = "0.4.75"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "54568702fabf5d4849ce2b90fadfa64168a097eaf4b351ce9df8b687a0086aaf"
+checksum = "503b14d284f2c8dac03b819967e155ea753f573586193b2b2c95990cb5d69280"
 dependencies = [
  "js-sys",
  "wasm-bindgen",
@@ -6414,9 +6365,9 @@ dependencies = [
 
 [[package]]
 name = "wasm-bindgen-macro"
-version = "0.2.123"
+version = "0.2.125"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "24a40fc75b0ec6f3746ceb10d36f53a93dcd68a93b11b6445983945d79eba0dc"
+checksum = "4e21a184b13fb19e157296e2c46056aec9092264fab83e4ba59e68c61b323c3d"
 dependencies = [
  "quote",
  "wasm-bindgen-macro-support",
@@ -6424,9 +6375,9 @@ dependencies = [
 
 [[package]]
 name = "wasm-bindgen-macro-support"
-version = "0.2.123"
+version = "0.2.125"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "908f34bd9b9ce3d4caf07b72dfab63d61504d156856c6bd3cd87fa350cf3985b"
+checksum = "fecefd9c35bd935a20fc3fc344b5f29138961e4f47fb03297d88f2587afb5ebd"
 dependencies = [
  "bumpalo",
  "proc-macro2",
@@ -6437,45 +6388,11 @@ dependencies = [
 
 [[package]]
 name = "wasm-bindgen-shared"
-version = "0.2.123"
+version = "0.2.125"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "7acbf7616c27b194bbb550bf77ed0c2c3e5b7fd1260a93082b95fb7f47959b92"
+checksum = "23939e44bb9a5d7576fa2b563dc2e136628f1224e88a8deed09e04858b77871f"
 dependencies = [
  "unicode-ident",
-]
-
-[[package]]
-name = "wasm-encoder"
-version = "0.244.0"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "990065f2fe63003fe337b932cfb5e3b80e0b4d0f5ff650e6985b1048f62c8319"
-dependencies = [
- "leb128fmt",
- "wasmparser",
-]
-
-[[package]]
-name = "wasm-metadata"
-version = "0.244.0"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "bb0e353e6a2fbdc176932bbaab493762eb1255a7900fe0fea1a2f96c296cc909"
-dependencies = [
- "anyhow",
- "indexmap 2.14.0",
- "wasm-encoder",
- "wasmparser",
-]
-
-[[package]]
-name = "wasmparser"
-version = "0.244.0"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "47b807c72e1bac69382b3a6fb3dbe8ea4c0ed87ff5629b8685ae6b9a611028fe"
-dependencies = [
- "bitflags",
- "hashbrown 0.15.5",
- "indexmap 2.14.0",
- "semver",
 ]
 
 [[package]]
@@ -6492,9 +6409,9 @@ dependencies = [
 
 [[package]]
 name = "web-sys"
-version = "0.3.100"
+version = "0.3.102"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "6e0871acf327f283dc6da28a1696cdc64fb355ba9f935d052021fa77f35cce69"
+checksum = "a6430a72df5eb332242960fe84b3002a241163998241eb596d4f739b9757061d"
 dependencies = [
  "js-sys",
  "wasm-bindgen",
@@ -6512,9 +6429,9 @@ dependencies = [
 
 [[package]]
 name = "webpki-root-certs"
-version = "1.0.7"
+version = "1.0.8"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "f31141ce3fc3e300ae89b78c0dd67f9708061d1d2eda54b8209346fd6be9a92c"
+checksum = "0d46a5a140e6f7afeccd8eae97eff335163939eac8b929834875168b29b3d267"
 dependencies = [
  "rustls-pki-types",
 ]
@@ -6525,14 +6442,14 @@ version = "0.26.11"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "521bc38abb08001b01866da9f51eb7c5d647a19260e00054a8c7fd5f9e57f7a9"
 dependencies = [
- "webpki-roots 1.0.7",
+ "webpki-roots 1.0.8",
 ]
 
 [[package]]
 name = "webpki-roots"
-version = "1.0.7"
+version = "1.0.8"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "52f5ee44c96cf55f1b349600768e3ece3a8f26010c05265ab73f945bb1a2eb9d"
+checksum = "bf85cb06032201fa7c6f829d7db5a7e5aa45bcc0655327713065f6f0576731bf"
 dependencies = [
  "rustls-pki-types",
 ]
@@ -7023,97 +6940,9 @@ dependencies = [
 
 [[package]]
 name = "wit-bindgen"
-version = "0.51.0"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "d7249219f66ced02969388cf2bb044a09756a083d0fab1e566056b04d9fbcaa5"
-dependencies = [
- "wit-bindgen-rust-macro",
-]
-
-[[package]]
-name = "wit-bindgen"
 version = "0.57.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "1ebf944e87a7c253233ad6766e082e3cd714b5d03812acc24c318f549614536e"
-
-[[package]]
-name = "wit-bindgen-core"
-version = "0.51.0"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "ea61de684c3ea68cb082b7a88508a8b27fcc8b797d738bfc99a82facf1d752dc"
-dependencies = [
- "anyhow",
- "heck",
- "wit-parser",
-]
-
-[[package]]
-name = "wit-bindgen-rust"
-version = "0.51.0"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "b7c566e0f4b284dd6561c786d9cb0142da491f46a9fbed79ea69cdad5db17f21"
-dependencies = [
- "anyhow",
- "heck",
- "indexmap 2.14.0",
- "prettyplease",
- "syn",
- "wasm-metadata",
- "wit-bindgen-core",
- "wit-component",
-]
-
-[[package]]
-name = "wit-bindgen-rust-macro"
-version = "0.51.0"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "0c0f9bfd77e6a48eccf51359e3ae77140a7f50b1e2ebfe62422d8afdaffab17a"
-dependencies = [
- "anyhow",
- "prettyplease",
- "proc-macro2",
- "quote",
- "syn",
- "wit-bindgen-core",
- "wit-bindgen-rust",
-]
-
-[[package]]
-name = "wit-component"
-version = "0.244.0"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "9d66ea20e9553b30172b5e831994e35fbde2d165325bec84fc43dbf6f4eb9cb2"
-dependencies = [
- "anyhow",
- "bitflags",
- "indexmap 2.14.0",
- "log",
- "serde",
- "serde_derive",
- "serde_json",
- "wasm-encoder",
- "wasm-metadata",
- "wasmparser",
- "wit-parser",
-]
-
-[[package]]
-name = "wit-parser"
-version = "0.244.0"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "ecc8ac4bc1dc3381b7f59c34f00b67e18f910c2c0f50015669dde7def656a736"
-dependencies = [
- "anyhow",
- "id-arena",
- "indexmap 2.14.0",
- "log",
- "semver",
- "serde",
- "serde_derive",
- "serde_json",
- "unicode-xid",
- "wasmparser",
-]
 
 [[package]]
 name = "writeable"
@@ -7218,18 +7047,18 @@ dependencies = [
 
 [[package]]
 name = "zeroize"
-version = "1.8.2"
+version = "1.9.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "b97154e67e32c85465826e8bcc1c59429aaaf107c1e4a9e53c8d8ccd5eff88d0"
+checksum = "e13c156562582aa81c60cb29407084cdb54c4164760106ab78e6c5b0858cf64e"
 dependencies = [
  "zeroize_derive",
 ]
 
 [[package]]
 name = "zeroize_derive"
-version = "1.4.3"
+version = "1.5.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "85a5b4158499876c763cb03bc4e49185d3cccbabb15b33c627f7884f43db852e"
+checksum = "3c50655cbb0fe3fc43170059e702f1ce5e19b84cec58dc87b037a09935c2f328"
 dependencies = [
  "proc-macro2",
  "quote",

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -149,9 +149,9 @@ dependencies = [
 
 [[package]]
 name = "arrayvec"
-version = "0.7.6"
+version = "0.7.7"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "7c02d123df017efcdfbd739ef81735b36c5ba83ec3c59c80a9d7ecc718f92e50"
+checksum = "f02882884d3e1bc524fb12c79f107f6ad0e1cfd498c536ffb494301740995dfe"
 
 [[package]]
 name = "ash"
@@ -258,6 +258,12 @@ checksum = "b71798fca2c1fe1086445a7258a4bc81e6e49dcd24c8d0dd9a1e57395b603f51"
 
 [[package]]
 name = "bitflags"
+version = "1.3.2"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "bef38d45163c2f1dde094a7dfd33ccf595c92905c8f8f4fdc18d06fb1037718a"
+
+[[package]]
+name = "bitflags"
 version = "2.13.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "b4388bee8683e3d04af747c73422af53102d2bd24d9eadb6cbc100baef4b43f8"
@@ -301,6 +307,7 @@ checksum = "72f5acc6cb2ba439de613abc23857ec3d78374d8ed5ac84e9d11336e87da8649"
 [[package]]
 name = "burn"
 version = "0.22.0-pre.1"
+source = "git+https://github.com/tracel-ai/burn?rev=44605a412c0dd1b17b31ecb890cf1d3d474e5516#44605a412c0dd1b17b31ecb890cf1d3d474e5516"
 dependencies = [
  "burn-autodiff",
  "burn-core",
@@ -314,6 +321,7 @@ dependencies = [
 [[package]]
 name = "burn-autodiff"
 version = "0.22.0-pre.1"
+source = "git+https://github.com/tracel-ai/burn?rev=44605a412c0dd1b17b31ecb890cf1d3d474e5516#44605a412c0dd1b17b31ecb890cf1d3d474e5516"
 dependencies = [
  "burn-backend",
  "burn-std",
@@ -330,6 +338,7 @@ dependencies = [
 [[package]]
 name = "burn-backend"
 version = "0.22.0-pre.1"
+source = "git+https://github.com/tracel-ai/burn?rev=44605a412c0dd1b17b31ecb890cf1d3d474e5516#44605a412c0dd1b17b31ecb890cf1d3d474e5516"
 dependencies = [
  "burn-std",
  "bytemuck",
@@ -349,6 +358,7 @@ dependencies = [
 [[package]]
 name = "burn-backend-extension"
 version = "0.22.0-pre.1"
+source = "git+https://github.com/tracel-ai/burn?rev=44605a412c0dd1b17b31ecb890cf1d3d474e5516#44605a412c0dd1b17b31ecb890cf1d3d474e5516"
 dependencies = [
  "proc-macro2",
  "quote",
@@ -358,6 +368,7 @@ dependencies = [
 [[package]]
 name = "burn-core"
 version = "0.22.0-pre.1"
+source = "git+https://github.com/tracel-ai/burn?rev=44605a412c0dd1b17b31ecb890cf1d3d474e5516#44605a412c0dd1b17b31ecb890cf1d3d474e5516"
 dependencies = [
  "ahash",
  "burn-backend",
@@ -376,6 +387,7 @@ dependencies = [
  "portable-atomic",
  "portable-atomic-util",
  "rand 0.10.1",
+ "regex",
  "serde",
  "serde_json",
  "spin",
@@ -384,6 +396,7 @@ dependencies = [
 [[package]]
 name = "burn-cpu"
 version = "0.22.0-pre.1"
+source = "git+https://github.com/tracel-ai/burn?rev=44605a412c0dd1b17b31ecb890cf1d3d474e5516#44605a412c0dd1b17b31ecb890cf1d3d474e5516"
 dependencies = [
  "burn-backend",
  "burn-cubecl",
@@ -393,6 +406,7 @@ dependencies = [
 [[package]]
 name = "burn-cubecl"
 version = "0.22.0-pre.1"
+source = "git+https://github.com/tracel-ai/burn?rev=44605a412c0dd1b17b31ecb890cf1d3d474e5516#44605a412c0dd1b17b31ecb890cf1d3d474e5516"
 dependencies = [
  "burn-backend",
  "burn-cubecl-fusion",
@@ -411,6 +425,7 @@ dependencies = [
 [[package]]
 name = "burn-cubecl-fusion"
 version = "0.22.0-pre.1"
+source = "git+https://github.com/tracel-ai/burn?rev=44605a412c0dd1b17b31ecb890cf1d3d474e5516#44605a412c0dd1b17b31ecb890cf1d3d474e5516"
 dependencies = [
  "burn-backend",
  "burn-fusion",
@@ -427,6 +442,7 @@ dependencies = [
 [[package]]
 name = "burn-cuda"
 version = "0.22.0-pre.1"
+source = "git+https://github.com/tracel-ai/burn?rev=44605a412c0dd1b17b31ecb890cf1d3d474e5516#44605a412c0dd1b17b31ecb890cf1d3d474e5516"
 dependencies = [
  "burn-backend",
  "burn-cubecl",
@@ -436,6 +452,7 @@ dependencies = [
 [[package]]
 name = "burn-dataset"
 version = "0.22.0-pre.1"
+source = "git+https://github.com/tracel-ai/burn?rev=44605a412c0dd1b17b31ecb890cf1d3d474e5516#44605a412c0dd1b17b31ecb890cf1d3d474e5516"
 dependencies = [
  "csv",
  "derive-new",
@@ -453,6 +470,7 @@ dependencies = [
 [[package]]
 name = "burn-derive"
 version = "0.22.0-pre.1"
+source = "git+https://github.com/tracel-ai/burn?rev=44605a412c0dd1b17b31ecb890cf1d3d474e5516#44605a412c0dd1b17b31ecb890cf1d3d474e5516"
 dependencies = [
  "derive-new",
  "proc-macro2",
@@ -463,6 +481,7 @@ dependencies = [
 [[package]]
 name = "burn-dispatch"
 version = "0.22.0-pre.1"
+source = "git+https://github.com/tracel-ai/burn?rev=44605a412c0dd1b17b31ecb890cf1d3d474e5516#44605a412c0dd1b17b31ecb890cf1d3d474e5516"
 dependencies = [
  "burn-autodiff",
  "burn-backend",
@@ -479,6 +498,7 @@ dependencies = [
 [[package]]
 name = "burn-flex"
 version = "0.22.0-pre.1"
+source = "git+https://github.com/tracel-ai/burn?rev=44605a412c0dd1b17b31ecb890cf1d3d474e5516#44605a412c0dd1b17b31ecb890cf1d3d474e5516"
 dependencies = [
  "aligned-vec",
  "burn-backend",
@@ -499,6 +519,7 @@ dependencies = [
 [[package]]
 name = "burn-fusion"
 version = "0.22.0-pre.1"
+source = "git+https://github.com/tracel-ai/burn?rev=44605a412c0dd1b17b31ecb890cf1d3d474e5516#44605a412c0dd1b17b31ecb890cf1d3d474e5516"
 dependencies = [
  "burn-backend",
  "burn-ir",
@@ -515,6 +536,7 @@ dependencies = [
 [[package]]
 name = "burn-ir"
 version = "0.22.0-pre.1"
+source = "git+https://github.com/tracel-ai/burn?rev=44605a412c0dd1b17b31ecb890cf1d3d474e5516#44605a412c0dd1b17b31ecb890cf1d3d474e5516"
 dependencies = [
  "burn-backend",
  "hashbrown 0.16.1",
@@ -524,6 +546,7 @@ dependencies = [
 [[package]]
 name = "burn-ndarray"
 version = "0.22.0-pre.1"
+source = "git+https://github.com/tracel-ai/burn?rev=44605a412c0dd1b17b31ecb890cf1d3d474e5516#44605a412c0dd1b17b31ecb890cf1d3d474e5516"
 dependencies = [
  "atomic_float",
  "burn-autodiff",
@@ -545,6 +568,7 @@ dependencies = [
 [[package]]
 name = "burn-nn"
 version = "0.22.0-pre.1"
+source = "git+https://github.com/tracel-ai/burn?rev=44605a412c0dd1b17b31ecb890cf1d3d474e5516#44605a412c0dd1b17b31ecb890cf1d3d474e5516"
 dependencies = [
  "burn-core",
  "num-traits",
@@ -553,6 +577,7 @@ dependencies = [
 [[package]]
 name = "burn-optim"
 version = "0.22.0-pre.1"
+source = "git+https://github.com/tracel-ai/burn?rev=44605a412c0dd1b17b31ecb890cf1d3d474e5516#44605a412c0dd1b17b31ecb890cf1d3d474e5516"
 dependencies = [
  "burn-core",
  "burn-derive",
@@ -567,6 +592,7 @@ dependencies = [
 [[package]]
 name = "burn-pack"
 version = "0.22.0-pre.1"
+source = "git+https://github.com/tracel-ai/burn?rev=44605a412c0dd1b17b31ecb890cf1d3d474e5516#44605a412c0dd1b17b31ecb890cf1d3d474e5516"
 dependencies = [
  "burn-std",
  "byteorder",
@@ -577,6 +603,7 @@ dependencies = [
 [[package]]
 name = "burn-rocm"
 version = "0.22.0-pre.1"
+source = "git+https://github.com/tracel-ai/burn?rev=44605a412c0dd1b17b31ecb890cf1d3d474e5516#44605a412c0dd1b17b31ecb890cf1d3d474e5516"
 dependencies = [
  "burn-backend",
  "burn-cubecl",
@@ -586,6 +613,7 @@ dependencies = [
 [[package]]
 name = "burn-std"
 version = "0.22.0-pre.1"
+source = "git+https://github.com/tracel-ai/burn?rev=44605a412c0dd1b17b31ecb890cf1d3d474e5516#44605a412c0dd1b17b31ecb890cf1d3d474e5516"
 dependencies = [
  "ahash",
  "bytemuck",
@@ -611,6 +639,7 @@ dependencies = [
 [[package]]
 name = "burn-tch"
 version = "0.22.0-pre.1"
+source = "git+https://github.com/tracel-ai/burn?rev=44605a412c0dd1b17b31ecb890cf1d3d474e5516#44605a412c0dd1b17b31ecb890cf1d3d474e5516"
 dependencies = [
  "burn-backend",
  "cc",
@@ -623,6 +652,7 @@ dependencies = [
 [[package]]
 name = "burn-tensor"
 version = "0.22.0-pre.1"
+source = "git+https://github.com/tracel-ai/burn?rev=44605a412c0dd1b17b31ecb890cf1d3d474e5516#44605a412c0dd1b17b31ecb890cf1d3d474e5516"
 dependencies = [
  "burn-backend",
  "burn-dispatch",
@@ -636,6 +666,7 @@ dependencies = [
 [[package]]
 name = "burn-train"
 version = "0.22.0-pre.1"
+source = "git+https://github.com/tracel-ai/burn?rev=44605a412c0dd1b17b31ecb890cf1d3d474e5516#44605a412c0dd1b17b31ecb890cf1d3d474e5516"
 dependencies = [
  "async-channel",
  "burn-core",
@@ -656,6 +687,7 @@ dependencies = [
 [[package]]
 name = "burn-wgpu"
 version = "0.22.0-pre.1"
+source = "git+https://github.com/tracel-ai/burn?rev=44605a412c0dd1b17b31ecb890cf1d3d474e5516#44605a412c0dd1b17b31ecb890cf1d3d474e5516"
 dependencies = [
  "burn-backend",
  "burn-cubecl",
@@ -1150,7 +1182,7 @@ version = "0.29.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "d8b9f2e4c67f833b660cdb0a3523065869fb35570177239812ed4c905aeff87b"
 dependencies = [
- "bitflags",
+ "bitflags 2.13.0",
  "crossterm_winapi",
  "derive_more",
  "document-features",
@@ -1281,7 +1313,7 @@ name = "cubecl-core"
 version = "0.11.0-pre.1"
 source = "git+https://github.com/tracel-ai/cubecl?rev=945cce851dd7d0614e127fbf9a63e767c04ebdda#945cce851dd7d0614e127fbf9a63e767c04ebdda"
 dependencies = [
- "bitflags",
+ "bitflags 2.13.0",
  "bytemuck",
  "cubecl-common",
  "cubecl-ir",
@@ -1830,6 +1862,38 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "ac6b926516df9c60bfa16e107b21086399f8285a44ca9711344b9e553c5146e2"
 
 [[package]]
+name = "defmt"
+version = "1.1.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "a6e524506490a1953d237cb87b1cfc1e46f88c18f10a22dfe0f507dc6bfc7f7f"
+dependencies = [
+ "bitflags 1.3.2",
+ "defmt-macros",
+]
+
+[[package]]
+name = "defmt-macros"
+version = "1.1.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "f0a27770e9c8f719a79d8b638281f4d828f77d8fd61e0bd94451b9b85e576a0b"
+dependencies = [
+ "defmt-parser",
+ "proc-macro-error2",
+ "proc-macro2",
+ "quote",
+ "syn",
+]
+
+[[package]]
+name = "defmt-parser"
+version = "1.0.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "10d60334b3b2e7c9d91ef8150abfb6fa4c1c39ebbcf4a81c2e346aad939fee3e"
+dependencies = [
+ "thiserror 2.0.18",
+]
+
+[[package]]
 name = "deranged"
 version = "0.5.8"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -1936,7 +2000,7 @@ version = "0.3.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "1e0e367e4e7da84520dedcac1901e4da967309406d1e51017ae1abfb97adbd38"
 dependencies = [
- "bitflags",
+ "bitflags 2.13.0",
  "block2",
  "libc",
  "objc2",
@@ -1983,7 +2047,7 @@ version = "0.15.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "7a41816e58f47f49acfd956651055ddcf137c4882c2098c30c448817af21183a"
 dependencies = [
- "bitflags",
+ "bitflags 2.13.0",
  "bytemuck",
  "bytemuck_derive",
  "drm-ffi",
@@ -2672,7 +2736,7 @@ version = "0.3.2"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "b89c83349105e3732062a895becfc71a8f921bb71ecbbdd8ff99263e3b53a0ca"
 dependencies = [
- "bitflags",
+ "bitflags 2.13.0",
  "gpu-descriptor-types",
  "hashbrown 0.15.5",
 ]
@@ -2683,7 +2747,7 @@ version = "0.2.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "fdf242682df893b86f33a73828fb09ca4b2d3bb6cc95249707fc684d27484b91"
 dependencies = [
- "bitflags",
+ "bitflags 2.13.0",
 ]
 
 [[package]]
@@ -3091,7 +3155,7 @@ version = "0.9.4"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "6654738b8024300cf062d04a1c13c10c8e2cea598ec1c47dc9b6641159429756"
 dependencies = [
- "bitflags",
+ "bitflags 2.13.0",
  "crossterm",
  "dyn-clone",
  "fuzzy-matcher",
@@ -3138,10 +3202,11 @@ checksum = "8f42a60cbdf9a97f5d2305f08a87dc4e09308d1276d28c869c684d7777685682"
 
 [[package]]
 name = "jiff"
-version = "0.2.28"
+version = "0.2.29"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "4603d3033e49e2b0e31229fcab20a5d40089c607d975cd9c80551dc69eed9102"
+checksum = "34f877a98676d2fb664698d74cc6a51ce6c484ce8c770f05d0108ec9090aeb46"
 dependencies = [
+ "defmt",
  "jiff-static",
  "log",
  "portable-atomic",
@@ -3151,9 +3216,9 @@ dependencies = [
 
 [[package]]
 name = "jiff-static"
-version = "0.2.28"
+version = "0.2.29"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "782d32378dddf207193ac91cefb848ad41abb58195c95168e1291227a0832b47"
+checksum = "0666b5ab5ecaca213fc2a85b8c0083d9004e84ee2d5f9a7e0017aaf50986f25f"
 dependencies = [
  "proc-macro2",
  "quote",
@@ -3393,9 +3458,9 @@ checksum = "9374ef4228402d4b7e403e5838cb880d9ee663314b0a900d5a6aabf0c213552e"
 
 [[package]]
 name = "log"
-version = "0.4.32"
+version = "0.4.33"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "953f07c43838f8e6f9758cab68bf5bed85465e7587ebe0b823f1bcd81978ad3a"
+checksum = "0ceec5bc11778974d1bcb055b18002eba7f4b3518b6a0081b3af5f21666da9ad"
 
 [[package]]
 name = "lru-slab"
@@ -3567,7 +3632,7 @@ source = "git+https://github.com/gfx-rs/wgpu.git?rev=bde709122f8320571ab1733ab05
 dependencies = [
  "arrayvec",
  "bit-set",
- "bitflags",
+ "bitflags 2.13.0",
  "cfg-if",
  "cfg_aliases",
  "codespan-reporting",
@@ -3670,7 +3735,7 @@ version = "0.31.3"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "cf20d2fde8ff38632c426f1165ed7436270b44f199fc55284c38276f9db47c3d"
 dependencies = [
- "bitflags",
+ "bitflags 2.13.0",
  "cfg-if",
  "cfg_aliases",
  "libc",
@@ -3809,7 +3874,7 @@ version = "0.3.2"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "2a180dd8642fa45cdb7dd721cd4c11b1cadd4929ce112ebd8b9f5803cc79d536"
 dependencies = [
- "bitflags",
+ "bitflags 2.13.0",
  "dispatch2",
  "objc2",
 ]
@@ -3826,7 +3891,7 @@ version = "0.3.2"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "e3e0adef53c21f888deb4fa59fc59f7eb17404926ee8a6f59f5df0fd7f9f3272"
 dependencies = [
- "bitflags",
+ "bitflags 2.13.0",
  "objc2",
  "objc2-core-foundation",
 ]
@@ -3847,7 +3912,7 @@ version = "0.3.2"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "a0125f776a10d00af4152d74616409f0d4a2053a6f57fa5b7d6aa2854ac04794"
 dependencies = [
- "bitflags",
+ "bitflags 2.13.0",
  "block2",
  "objc2",
  "objc2-foundation",
@@ -3859,7 +3924,7 @@ version = "0.3.2"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "96c1358452b371bf9f104e21ec536d37a650eb10f7ee379fff67d2e08d537f1f"
 dependencies = [
- "bitflags",
+ "bitflags 2.13.0",
  "objc2",
  "objc2-core-foundation",
  "objc2-foundation",
@@ -3903,7 +3968,7 @@ version = "0.10.81"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "77823a27f0babb03091cb9ed9ef80af3b39dbc82f97e8fa530374b7dafd87a45"
 dependencies = [
- "bitflags",
+ "bitflags 2.13.0",
  "cfg-if",
  "foreign-types",
  "libc",
@@ -4134,6 +4199,28 @@ dependencies = [
 ]
 
 [[package]]
+name = "proc-macro-error-attr2"
+version = "2.0.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "96de42df36bb9bba5542fe9f1a054b8cc87e172759a1868aa05c1f3acc89dfc5"
+dependencies = [
+ "proc-macro2",
+ "quote",
+]
+
+[[package]]
+name = "proc-macro-error2"
+version = "2.0.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "11ec05c52be0a07b08061f7dd003e7d7092e0472bc731b4af7bb1ef876109802"
+dependencies = [
+ "proc-macro-error-attr2",
+ "proc-macro2",
+ "quote",
+ "syn",
+]
+
+[[package]]
 name = "proc-macro2"
 version = "1.0.106"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -4150,9 +4237,9 @@ checksum = "3d595e54a326bc53c1c197b32d295e14b169e3cfeaa8dc82b529f947fba6bcf5"
 
 [[package]]
 name = "pulp"
-version = "0.22.2"
+version = "0.22.3"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "2e205bb30d5b916c55e584c22201771bcf2bad9aabd5d4127f38387140c38632"
+checksum = "046aa45b989642ec2e4717c8e72d677b13edd831a4d3b6cf37d9a3e54912496a"
 dependencies = [
  "bytemuck",
  "cfg-if",
@@ -4167,9 +4254,9 @@ dependencies = [
 
 [[package]]
 name = "pulp-wasm-simd-flag"
-version = "0.1.0"
+version = "0.1.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "40e24eee682d89fb193496edf918a7f407d30175b2e785fe057e4392dfd182e0"
+checksum = "1d8f70e07b9c3962945a74e59ca1c511bba65b6419468acc217c457d93f3c740"
 
 [[package]]
 name = "quanta"
@@ -4188,9 +4275,9 @@ dependencies = [
 
 [[package]]
 name = "quinn"
-version = "0.11.9"
+version = "0.11.11"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "b9e20a958963c291dc322d98411f541009df2ced7b5a4f2bd52337638cfccf20"
+checksum = "0c1a41e437b6bbd489372cd4971de128e85c855f56c57f283d20ff016cf7c0a8"
 dependencies = [
  "bytes",
  "cfg_aliases",
@@ -4208,9 +4295,9 @@ dependencies = [
 
 [[package]]
 name = "quinn-proto"
-version = "0.11.14"
+version = "0.11.15"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "434b42fec591c96ef50e21e886936e66d3cc3f737104fdb9b737c40ffb94c098"
+checksum = "4fcb935c5bec503c2f0e306bdd3e58bb9029dcb14fa8d9ac76e3a5256ac0763e"
 dependencies = [
  "aws-lc-rs",
  "bytes",
@@ -4244,9 +4331,9 @@ dependencies = [
 
 [[package]]
 name = "quote"
-version = "1.0.45"
+version = "1.0.46"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "41f2619966050689382d2b44f664f4bc593e129785a36d6ee376ddf37259b924"
+checksum = "dfbc457d0c7a0759a614551b11a6409e5951f6c7537be1f1b7682b9ae9230368"
 dependencies = [
  "proc-macro2",
 ]
@@ -4389,7 +4476,7 @@ version = "11.6.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "498cd0dc59d73224351ee52a95fee0f1a617a2eae0e7d9d720cc622c73a54186"
 dependencies = [
- "bitflags",
+ "bitflags 2.13.0",
 ]
 
 [[package]]
@@ -4448,7 +4535,7 @@ version = "0.5.18"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "ed2bf2547551a7053d6fdfafda3f938979645c44812fbfcda098faae3f1a362d"
 dependencies = [
- "bitflags",
+ "bitflags 2.13.0",
 ]
 
 [[package]]
@@ -4701,7 +4788,7 @@ version = "1.1.4"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "b6fe4565b9518b83ef4f91bb47ce29620ca828bd32cb7e408f0062e9930ba190"
 dependencies = [
- "bitflags",
+ "bitflags 2.13.0",
  "errno",
  "libc",
  "linux-raw-sys 0.12.1",
@@ -4710,9 +4797,9 @@ dependencies = [
 
 [[package]]
 name = "rustls"
-version = "0.23.40"
+version = "0.23.41"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "ef86cd5876211988985292b91c96a8f2d298df24e75989a43a3c73f2d4d8168b"
+checksum = "6b92b125634d9b795e7beca796cc790df15a7fb38323bf3196fda83292d06b1f"
 dependencies = [
  "aws-lc-rs",
  "log",
@@ -4870,7 +4957,7 @@ version = "3.7.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "b7f4bc775c73d9a02cde8bf7b2ec4c9d12743edf609006c7facc23998404cd1d"
 dependencies = [
- "bitflags",
+ "bitflags 2.13.0",
  "core-foundation 0.10.1",
  "core-foundation-sys",
  "libc",
@@ -5161,7 +5248,7 @@ version = "0.4.0+sdk-1.4.341.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "d9571ea910ebd84c86af4b3ed27f9dbdc6ad06f17c5f96146b2b671e2976744f"
 dependencies = [
- "bitflags",
+ "bitflags 2.13.0",
 ]
 
 [[package]]
@@ -5292,7 +5379,7 @@ version = "0.6.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "01198a2debb237c62b6826ec7081082d951f46dbb64b0e8c7649a452230d1dfc"
 dependencies = [
- "bitflags",
+ "bitflags 2.13.0",
  "byteorder",
  "enum-as-inner",
  "libc",
@@ -5320,7 +5407,7 @@ version = "0.7.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "a13f3d0daba03132c0aa9767f98351b3488edc2c100cda2d2ec2b04f3d8d3c8b"
 dependencies = [
- "bitflags",
+ "bitflags 2.13.0",
  "core-foundation 0.9.4",
  "system-configuration-sys",
 ]
@@ -5447,9 +5534,9 @@ dependencies = [
 
 [[package]]
 name = "time"
-version = "0.3.49"
+version = "0.3.51"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "711a53c2d47bbd818258c498c8dbfe186a2526c631495cfe7e078567f86b8469"
+checksum = "85c17d80feb7334b40c484e45ed1a5273dfd8bfda537c3be2e74a06a6686f327"
 dependencies = [
  "deranged",
  "num-conv",
@@ -5467,9 +5554,9 @@ checksum = "9e1c906769ad99c88eaa54e728060edef082f8e358ff32030cb7c7d315e81109"
 
 [[package]]
 name = "time-macros"
-version = "0.2.29"
+version = "0.2.30"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "71c652a3727a9cbb9a02f707f530b618ce00d0ccd762009c8c23bd191df3c17d"
+checksum = "dcef1a61bdb119096e153208ec5cbec23944ce8bca13be5c7f60c634f7403935"
 dependencies = [
  "num-conv",
  "time-core",
@@ -5668,7 +5755,7 @@ version = "0.6.11"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "4cfcf7e2740e6fc6d4d688b4ef00650406bb94adf4731e43c096c3a19fe40840"
 dependencies = [
- "bitflags",
+ "bitflags 2.13.0",
  "bytes",
  "futures-util",
  "http",
@@ -6460,7 +6547,7 @@ version = "29.0.0"
 source = "git+https://github.com/gfx-rs/wgpu.git?rev=bde709122f8320571ab1733ab055dcb54415a483#bde709122f8320571ab1733ab055dcb54415a483"
 dependencies = [
  "arrayvec",
- "bitflags",
+ "bitflags 2.13.0",
  "bytemuck",
  "cfg-if",
  "cfg_aliases",
@@ -6491,7 +6578,7 @@ dependencies = [
  "arrayvec",
  "bit-set",
  "bit-vec",
- "bitflags",
+ "bitflags 2.13.0",
  "bytemuck",
  "cfg_aliases",
  "document-features",
@@ -6548,7 +6635,7 @@ dependencies = [
  "arrayvec",
  "ash",
  "bit-set",
- "bitflags",
+ "bitflags 2.13.0",
  "block2",
  "bytemuck",
  "cfg-if",
@@ -6607,7 +6694,7 @@ name = "wgpu-types"
 version = "29.0.0"
 source = "git+https://github.com/gfx-rs/wgpu.git?rev=bde709122f8320571ab1733ab055dcb54415a483#bde709122f8320571ab1733ab055dcb54415a483"
 dependencies = [
- "bitflags",
+ "bitflags 2.13.0",
  "bytemuck",
  "js-sys",
  "log",
@@ -7147,9 +7234,9 @@ dependencies = [
 
 [[package]]
 name = "zlib-rs"
-version = "0.6.3"
+version = "0.6.4"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "3be3d40e40a133f9c916ee3f9f4fa2d9d63435b5fbe1bfc6d9dae0aa0ada1513"
+checksum = "977347db8caa080403f6b6b7c1cda9479a8e869316f7e13a59b19076a40f94e3"
 
 [[package]]
 name = "zmij"

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -307,7 +307,7 @@ checksum = "72f5acc6cb2ba439de613abc23857ec3d78374d8ed5ac84e9d11336e87da8649"
 [[package]]
 name = "burn"
 version = "0.22.0-pre.1"
-source = "git+https://github.com/tracel-ai/burn?rev=44605a412c0dd1b17b31ecb890cf1d3d474e5516#44605a412c0dd1b17b31ecb890cf1d3d474e5516"
+source = "git+https://github.com/tracel-ai/burn?rev=35ff68bd3b2faa6b6f651e5d7ab5939b4504f799#35ff68bd3b2faa6b6f651e5d7ab5939b4504f799"
 dependencies = [
  "burn-autodiff",
  "burn-core",
@@ -321,7 +321,7 @@ dependencies = [
 [[package]]
 name = "burn-autodiff"
 version = "0.22.0-pre.1"
-source = "git+https://github.com/tracel-ai/burn?rev=44605a412c0dd1b17b31ecb890cf1d3d474e5516#44605a412c0dd1b17b31ecb890cf1d3d474e5516"
+source = "git+https://github.com/tracel-ai/burn?rev=35ff68bd3b2faa6b6f651e5d7ab5939b4504f799#35ff68bd3b2faa6b6f651e5d7ab5939b4504f799"
 dependencies = [
  "burn-backend",
  "burn-std",
@@ -338,7 +338,7 @@ dependencies = [
 [[package]]
 name = "burn-backend"
 version = "0.22.0-pre.1"
-source = "git+https://github.com/tracel-ai/burn?rev=44605a412c0dd1b17b31ecb890cf1d3d474e5516#44605a412c0dd1b17b31ecb890cf1d3d474e5516"
+source = "git+https://github.com/tracel-ai/burn?rev=35ff68bd3b2faa6b6f651e5d7ab5939b4504f799#35ff68bd3b2faa6b6f651e5d7ab5939b4504f799"
 dependencies = [
  "burn-std",
  "bytemuck",
@@ -358,7 +358,7 @@ dependencies = [
 [[package]]
 name = "burn-backend-extension"
 version = "0.22.0-pre.1"
-source = "git+https://github.com/tracel-ai/burn?rev=44605a412c0dd1b17b31ecb890cf1d3d474e5516#44605a412c0dd1b17b31ecb890cf1d3d474e5516"
+source = "git+https://github.com/tracel-ai/burn?rev=35ff68bd3b2faa6b6f651e5d7ab5939b4504f799#35ff68bd3b2faa6b6f651e5d7ab5939b4504f799"
 dependencies = [
  "proc-macro2",
  "quote",
@@ -368,7 +368,7 @@ dependencies = [
 [[package]]
 name = "burn-core"
 version = "0.22.0-pre.1"
-source = "git+https://github.com/tracel-ai/burn?rev=44605a412c0dd1b17b31ecb890cf1d3d474e5516#44605a412c0dd1b17b31ecb890cf1d3d474e5516"
+source = "git+https://github.com/tracel-ai/burn?rev=35ff68bd3b2faa6b6f651e5d7ab5939b4504f799#35ff68bd3b2faa6b6f651e5d7ab5939b4504f799"
 dependencies = [
  "ahash",
  "burn-backend",
@@ -396,7 +396,7 @@ dependencies = [
 [[package]]
 name = "burn-cpu"
 version = "0.22.0-pre.1"
-source = "git+https://github.com/tracel-ai/burn?rev=44605a412c0dd1b17b31ecb890cf1d3d474e5516#44605a412c0dd1b17b31ecb890cf1d3d474e5516"
+source = "git+https://github.com/tracel-ai/burn?rev=35ff68bd3b2faa6b6f651e5d7ab5939b4504f799#35ff68bd3b2faa6b6f651e5d7ab5939b4504f799"
 dependencies = [
  "burn-backend",
  "burn-cubecl",
@@ -406,7 +406,7 @@ dependencies = [
 [[package]]
 name = "burn-cubecl"
 version = "0.22.0-pre.1"
-source = "git+https://github.com/tracel-ai/burn?rev=44605a412c0dd1b17b31ecb890cf1d3d474e5516#44605a412c0dd1b17b31ecb890cf1d3d474e5516"
+source = "git+https://github.com/tracel-ai/burn?rev=35ff68bd3b2faa6b6f651e5d7ab5939b4504f799#35ff68bd3b2faa6b6f651e5d7ab5939b4504f799"
 dependencies = [
  "burn-backend",
  "burn-cubecl-fusion",
@@ -425,7 +425,7 @@ dependencies = [
 [[package]]
 name = "burn-cubecl-fusion"
 version = "0.22.0-pre.1"
-source = "git+https://github.com/tracel-ai/burn?rev=44605a412c0dd1b17b31ecb890cf1d3d474e5516#44605a412c0dd1b17b31ecb890cf1d3d474e5516"
+source = "git+https://github.com/tracel-ai/burn?rev=35ff68bd3b2faa6b6f651e5d7ab5939b4504f799#35ff68bd3b2faa6b6f651e5d7ab5939b4504f799"
 dependencies = [
  "burn-backend",
  "burn-fusion",
@@ -442,7 +442,7 @@ dependencies = [
 [[package]]
 name = "burn-cuda"
 version = "0.22.0-pre.1"
-source = "git+https://github.com/tracel-ai/burn?rev=44605a412c0dd1b17b31ecb890cf1d3d474e5516#44605a412c0dd1b17b31ecb890cf1d3d474e5516"
+source = "git+https://github.com/tracel-ai/burn?rev=35ff68bd3b2faa6b6f651e5d7ab5939b4504f799#35ff68bd3b2faa6b6f651e5d7ab5939b4504f799"
 dependencies = [
  "burn-backend",
  "burn-cubecl",
@@ -452,7 +452,7 @@ dependencies = [
 [[package]]
 name = "burn-dataset"
 version = "0.22.0-pre.1"
-source = "git+https://github.com/tracel-ai/burn?rev=44605a412c0dd1b17b31ecb890cf1d3d474e5516#44605a412c0dd1b17b31ecb890cf1d3d474e5516"
+source = "git+https://github.com/tracel-ai/burn?rev=35ff68bd3b2faa6b6f651e5d7ab5939b4504f799#35ff68bd3b2faa6b6f651e5d7ab5939b4504f799"
 dependencies = [
  "csv",
  "derive-new",
@@ -470,7 +470,7 @@ dependencies = [
 [[package]]
 name = "burn-derive"
 version = "0.22.0-pre.1"
-source = "git+https://github.com/tracel-ai/burn?rev=44605a412c0dd1b17b31ecb890cf1d3d474e5516#44605a412c0dd1b17b31ecb890cf1d3d474e5516"
+source = "git+https://github.com/tracel-ai/burn?rev=35ff68bd3b2faa6b6f651e5d7ab5939b4504f799#35ff68bd3b2faa6b6f651e5d7ab5939b4504f799"
 dependencies = [
  "derive-new",
  "proc-macro2",
@@ -481,7 +481,7 @@ dependencies = [
 [[package]]
 name = "burn-dispatch"
 version = "0.22.0-pre.1"
-source = "git+https://github.com/tracel-ai/burn?rev=44605a412c0dd1b17b31ecb890cf1d3d474e5516#44605a412c0dd1b17b31ecb890cf1d3d474e5516"
+source = "git+https://github.com/tracel-ai/burn?rev=35ff68bd3b2faa6b6f651e5d7ab5939b4504f799#35ff68bd3b2faa6b6f651e5d7ab5939b4504f799"
 dependencies = [
  "burn-autodiff",
  "burn-backend",
@@ -498,7 +498,7 @@ dependencies = [
 [[package]]
 name = "burn-flex"
 version = "0.22.0-pre.1"
-source = "git+https://github.com/tracel-ai/burn?rev=44605a412c0dd1b17b31ecb890cf1d3d474e5516#44605a412c0dd1b17b31ecb890cf1d3d474e5516"
+source = "git+https://github.com/tracel-ai/burn?rev=35ff68bd3b2faa6b6f651e5d7ab5939b4504f799#35ff68bd3b2faa6b6f651e5d7ab5939b4504f799"
 dependencies = [
  "aligned-vec",
  "burn-backend",
@@ -519,7 +519,7 @@ dependencies = [
 [[package]]
 name = "burn-fusion"
 version = "0.22.0-pre.1"
-source = "git+https://github.com/tracel-ai/burn?rev=44605a412c0dd1b17b31ecb890cf1d3d474e5516#44605a412c0dd1b17b31ecb890cf1d3d474e5516"
+source = "git+https://github.com/tracel-ai/burn?rev=35ff68bd3b2faa6b6f651e5d7ab5939b4504f799#35ff68bd3b2faa6b6f651e5d7ab5939b4504f799"
 dependencies = [
  "burn-backend",
  "burn-ir",
@@ -536,7 +536,7 @@ dependencies = [
 [[package]]
 name = "burn-ir"
 version = "0.22.0-pre.1"
-source = "git+https://github.com/tracel-ai/burn?rev=44605a412c0dd1b17b31ecb890cf1d3d474e5516#44605a412c0dd1b17b31ecb890cf1d3d474e5516"
+source = "git+https://github.com/tracel-ai/burn?rev=35ff68bd3b2faa6b6f651e5d7ab5939b4504f799#35ff68bd3b2faa6b6f651e5d7ab5939b4504f799"
 dependencies = [
  "burn-backend",
  "hashbrown 0.16.1",
@@ -546,7 +546,7 @@ dependencies = [
 [[package]]
 name = "burn-ndarray"
 version = "0.22.0-pre.1"
-source = "git+https://github.com/tracel-ai/burn?rev=44605a412c0dd1b17b31ecb890cf1d3d474e5516#44605a412c0dd1b17b31ecb890cf1d3d474e5516"
+source = "git+https://github.com/tracel-ai/burn?rev=35ff68bd3b2faa6b6f651e5d7ab5939b4504f799#35ff68bd3b2faa6b6f651e5d7ab5939b4504f799"
 dependencies = [
  "atomic_float",
  "burn-autodiff",
@@ -568,7 +568,7 @@ dependencies = [
 [[package]]
 name = "burn-nn"
 version = "0.22.0-pre.1"
-source = "git+https://github.com/tracel-ai/burn?rev=44605a412c0dd1b17b31ecb890cf1d3d474e5516#44605a412c0dd1b17b31ecb890cf1d3d474e5516"
+source = "git+https://github.com/tracel-ai/burn?rev=35ff68bd3b2faa6b6f651e5d7ab5939b4504f799#35ff68bd3b2faa6b6f651e5d7ab5939b4504f799"
 dependencies = [
  "burn-core",
  "num-traits",
@@ -577,7 +577,7 @@ dependencies = [
 [[package]]
 name = "burn-optim"
 version = "0.22.0-pre.1"
-source = "git+https://github.com/tracel-ai/burn?rev=44605a412c0dd1b17b31ecb890cf1d3d474e5516#44605a412c0dd1b17b31ecb890cf1d3d474e5516"
+source = "git+https://github.com/tracel-ai/burn?rev=35ff68bd3b2faa6b6f651e5d7ab5939b4504f799#35ff68bd3b2faa6b6f651e5d7ab5939b4504f799"
 dependencies = [
  "burn-core",
  "burn-derive",
@@ -592,7 +592,7 @@ dependencies = [
 [[package]]
 name = "burn-pack"
 version = "0.22.0-pre.1"
-source = "git+https://github.com/tracel-ai/burn?rev=44605a412c0dd1b17b31ecb890cf1d3d474e5516#44605a412c0dd1b17b31ecb890cf1d3d474e5516"
+source = "git+https://github.com/tracel-ai/burn?rev=35ff68bd3b2faa6b6f651e5d7ab5939b4504f799#35ff68bd3b2faa6b6f651e5d7ab5939b4504f799"
 dependencies = [
  "burn-std",
  "byteorder",
@@ -603,7 +603,7 @@ dependencies = [
 [[package]]
 name = "burn-rocm"
 version = "0.22.0-pre.1"
-source = "git+https://github.com/tracel-ai/burn?rev=44605a412c0dd1b17b31ecb890cf1d3d474e5516#44605a412c0dd1b17b31ecb890cf1d3d474e5516"
+source = "git+https://github.com/tracel-ai/burn?rev=35ff68bd3b2faa6b6f651e5d7ab5939b4504f799#35ff68bd3b2faa6b6f651e5d7ab5939b4504f799"
 dependencies = [
  "burn-backend",
  "burn-cubecl",
@@ -613,7 +613,7 @@ dependencies = [
 [[package]]
 name = "burn-std"
 version = "0.22.0-pre.1"
-source = "git+https://github.com/tracel-ai/burn?rev=44605a412c0dd1b17b31ecb890cf1d3d474e5516#44605a412c0dd1b17b31ecb890cf1d3d474e5516"
+source = "git+https://github.com/tracel-ai/burn?rev=35ff68bd3b2faa6b6f651e5d7ab5939b4504f799#35ff68bd3b2faa6b6f651e5d7ab5939b4504f799"
 dependencies = [
  "ahash",
  "bytemuck",
@@ -639,7 +639,7 @@ dependencies = [
 [[package]]
 name = "burn-tch"
 version = "0.22.0-pre.1"
-source = "git+https://github.com/tracel-ai/burn?rev=44605a412c0dd1b17b31ecb890cf1d3d474e5516#44605a412c0dd1b17b31ecb890cf1d3d474e5516"
+source = "git+https://github.com/tracel-ai/burn?rev=35ff68bd3b2faa6b6f651e5d7ab5939b4504f799#35ff68bd3b2faa6b6f651e5d7ab5939b4504f799"
 dependencies = [
  "burn-backend",
  "cc",
@@ -652,7 +652,7 @@ dependencies = [
 [[package]]
 name = "burn-tensor"
 version = "0.22.0-pre.1"
-source = "git+https://github.com/tracel-ai/burn?rev=44605a412c0dd1b17b31ecb890cf1d3d474e5516#44605a412c0dd1b17b31ecb890cf1d3d474e5516"
+source = "git+https://github.com/tracel-ai/burn?rev=35ff68bd3b2faa6b6f651e5d7ab5939b4504f799#35ff68bd3b2faa6b6f651e5d7ab5939b4504f799"
 dependencies = [
  "burn-backend",
  "burn-dispatch",
@@ -666,7 +666,7 @@ dependencies = [
 [[package]]
 name = "burn-train"
 version = "0.22.0-pre.1"
-source = "git+https://github.com/tracel-ai/burn?rev=44605a412c0dd1b17b31ecb890cf1d3d474e5516#44605a412c0dd1b17b31ecb890cf1d3d474e5516"
+source = "git+https://github.com/tracel-ai/burn?rev=35ff68bd3b2faa6b6f651e5d7ab5939b4504f799#35ff68bd3b2faa6b6f651e5d7ab5939b4504f799"
 dependencies = [
  "async-channel",
  "burn-core",
@@ -687,7 +687,7 @@ dependencies = [
 [[package]]
 name = "burn-wgpu"
 version = "0.22.0-pre.1"
-source = "git+https://github.com/tracel-ai/burn?rev=44605a412c0dd1b17b31ecb890cf1d3d474e5516#44605a412c0dd1b17b31ecb890cf1d3d474e5516"
+source = "git+https://github.com/tracel-ai/burn?rev=35ff68bd3b2faa6b6f651e5d7ab5939b4504f799#35ff68bd3b2faa6b6f651e5d7ab5939b4504f799"
 dependencies = [
  "burn-backend",
  "burn-cubecl",
@@ -1254,7 +1254,7 @@ dependencies = [
 [[package]]
 name = "cubecl"
 version = "0.11.0-pre.1"
-source = "git+https://github.com/tracel-ai/cubecl?rev=945cce851dd7d0614e127fbf9a63e767c04ebdda#945cce851dd7d0614e127fbf9a63e767c04ebdda"
+source = "git+https://github.com/tracel-ai/cubecl?rev=3beb9afaa0acf2d3f7b2dfff4ebf6dedfb316825#3beb9afaa0acf2d3f7b2dfff4ebf6dedfb316825"
 dependencies = [
  "cubecl-core",
  "cubecl-cpu",
@@ -1270,7 +1270,7 @@ dependencies = [
 [[package]]
 name = "cubecl-common"
 version = "0.11.0-pre.1"
-source = "git+https://github.com/tracel-ai/cubecl?rev=945cce851dd7d0614e127fbf9a63e767c04ebdda#945cce851dd7d0614e127fbf9a63e767c04ebdda"
+source = "git+https://github.com/tracel-ai/cubecl?rev=3beb9afaa0acf2d3f7b2dfff4ebf6dedfb316825#3beb9afaa0acf2d3f7b2dfff4ebf6dedfb316825"
 dependencies = [
  "backtrace",
  "bytemuck",
@@ -1311,7 +1311,7 @@ dependencies = [
 [[package]]
 name = "cubecl-core"
 version = "0.11.0-pre.1"
-source = "git+https://github.com/tracel-ai/cubecl?rev=945cce851dd7d0614e127fbf9a63e767c04ebdda#945cce851dd7d0614e127fbf9a63e767c04ebdda"
+source = "git+https://github.com/tracel-ai/cubecl?rev=3beb9afaa0acf2d3f7b2dfff4ebf6dedfb316825#3beb9afaa0acf2d3f7b2dfff4ebf6dedfb316825"
 dependencies = [
  "bitflags 2.13.0",
  "bytemuck",
@@ -1340,7 +1340,7 @@ dependencies = [
 [[package]]
 name = "cubecl-cpp"
 version = "0.11.0-pre.1"
-source = "git+https://github.com/tracel-ai/cubecl?rev=945cce851dd7d0614e127fbf9a63e767c04ebdda#945cce851dd7d0614e127fbf9a63e767c04ebdda"
+source = "git+https://github.com/tracel-ai/cubecl?rev=3beb9afaa0acf2d3f7b2dfff4ebf6dedfb316825#3beb9afaa0acf2d3f7b2dfff4ebf6dedfb316825"
 dependencies = [
  "bytemuck",
  "cubecl-common",
@@ -1356,7 +1356,7 @@ dependencies = [
 [[package]]
 name = "cubecl-cpu"
 version = "0.11.0-pre.1"
-source = "git+https://github.com/tracel-ai/cubecl?rev=945cce851dd7d0614e127fbf9a63e767c04ebdda#945cce851dd7d0614e127fbf9a63e767c04ebdda"
+source = "git+https://github.com/tracel-ai/cubecl?rev=3beb9afaa0acf2d3f7b2dfff4ebf6dedfb316825#3beb9afaa0acf2d3f7b2dfff4ebf6dedfb316825"
 dependencies = [
  "bytemuck",
  "cubecl-common",
@@ -1379,7 +1379,7 @@ dependencies = [
 [[package]]
 name = "cubecl-cuda"
 version = "0.11.0-pre.1"
-source = "git+https://github.com/tracel-ai/cubecl?rev=945cce851dd7d0614e127fbf9a63e767c04ebdda#945cce851dd7d0614e127fbf9a63e767c04ebdda"
+source = "git+https://github.com/tracel-ai/cubecl?rev=3beb9afaa0acf2d3f7b2dfff4ebf6dedfb316825#3beb9afaa0acf2d3f7b2dfff4ebf6dedfb316825"
 dependencies = [
  "bytemuck",
  "cubecl-common",
@@ -1397,7 +1397,7 @@ dependencies = [
 [[package]]
 name = "cubecl-hip"
 version = "0.11.0-pre.1"
-source = "git+https://github.com/tracel-ai/cubecl?rev=945cce851dd7d0614e127fbf9a63e767c04ebdda#945cce851dd7d0614e127fbf9a63e767c04ebdda"
+source = "git+https://github.com/tracel-ai/cubecl?rev=3beb9afaa0acf2d3f7b2dfff4ebf6dedfb316825#3beb9afaa0acf2d3f7b2dfff4ebf6dedfb316825"
 dependencies = [
  "bytemuck",
  "cubecl-common",
@@ -1426,7 +1426,7 @@ dependencies = [
 [[package]]
 name = "cubecl-ir"
 version = "0.11.0-pre.1"
-source = "git+https://github.com/tracel-ai/cubecl?rev=945cce851dd7d0614e127fbf9a63e767c04ebdda#945cce851dd7d0614e127fbf9a63e767c04ebdda"
+source = "git+https://github.com/tracel-ai/cubecl?rev=3beb9afaa0acf2d3f7b2dfff4ebf6dedfb316825#3beb9afaa0acf2d3f7b2dfff4ebf6dedfb316825"
 dependencies = [
  "bumpalo",
  "cubecl-common",
@@ -1450,7 +1450,7 @@ dependencies = [
 [[package]]
 name = "cubecl-macros"
 version = "0.11.0-pre.1"
-source = "git+https://github.com/tracel-ai/cubecl?rev=945cce851dd7d0614e127fbf9a63e767c04ebdda#945cce851dd7d0614e127fbf9a63e767c04ebdda"
+source = "git+https://github.com/tracel-ai/cubecl?rev=3beb9afaa0acf2d3f7b2dfff4ebf6dedfb316825#3beb9afaa0acf2d3f7b2dfff4ebf6dedfb316825"
 dependencies = [
  "cubecl-common",
  "darling 0.23.0",
@@ -1467,7 +1467,7 @@ dependencies = [
 [[package]]
 name = "cubecl-macros-internal"
 version = "0.11.0-pre.1"
-source = "git+https://github.com/tracel-ai/cubecl?rev=945cce851dd7d0614e127fbf9a63e767c04ebdda#945cce851dd7d0614e127fbf9a63e767c04ebdda"
+source = "git+https://github.com/tracel-ai/cubecl?rev=3beb9afaa0acf2d3f7b2dfff4ebf6dedfb316825#3beb9afaa0acf2d3f7b2dfff4ebf6dedfb316825"
 dependencies = [
  "darling 0.23.0",
  "proc-macro2",
@@ -1478,7 +1478,7 @@ dependencies = [
 [[package]]
 name = "cubecl-opt"
 version = "0.11.0-pre.1"
-source = "git+https://github.com/tracel-ai/cubecl?rev=945cce851dd7d0614e127fbf9a63e767c04ebdda#945cce851dd7d0614e127fbf9a63e767c04ebdda"
+source = "git+https://github.com/tracel-ai/cubecl?rev=3beb9afaa0acf2d3f7b2dfff4ebf6dedfb316825#3beb9afaa0acf2d3f7b2dfff4ebf6dedfb316825"
 dependencies = [
  "cubecl-common",
  "cubecl-core",
@@ -1496,7 +1496,7 @@ dependencies = [
 [[package]]
 name = "cubecl-runtime"
 version = "0.11.0-pre.1"
-source = "git+https://github.com/tracel-ai/cubecl?rev=945cce851dd7d0614e127fbf9a63e767c04ebdda#945cce851dd7d0614e127fbf9a63e767c04ebdda"
+source = "git+https://github.com/tracel-ai/cubecl?rev=3beb9afaa0acf2d3f7b2dfff4ebf6dedfb316825#3beb9afaa0acf2d3f7b2dfff4ebf6dedfb316825"
 dependencies = [
  "ahash",
  "async-channel",
@@ -1527,7 +1527,7 @@ dependencies = [
 [[package]]
 name = "cubecl-std"
 version = "0.11.0-pre.1"
-source = "git+https://github.com/tracel-ai/cubecl?rev=945cce851dd7d0614e127fbf9a63e767c04ebdda#945cce851dd7d0614e127fbf9a63e767c04ebdda"
+source = "git+https://github.com/tracel-ai/cubecl?rev=3beb9afaa0acf2d3f7b2dfff4ebf6dedfb316825#3beb9afaa0acf2d3f7b2dfff4ebf6dedfb316825"
 dependencies = [
  "cubecl-common",
  "cubecl-core",
@@ -1543,7 +1543,7 @@ dependencies = [
 [[package]]
 name = "cubecl-wgpu"
 version = "0.11.0-pre.1"
-source = "git+https://github.com/tracel-ai/cubecl?rev=945cce851dd7d0614e127fbf9a63e767c04ebdda#945cce851dd7d0614e127fbf9a63e767c04ebdda"
+source = "git+https://github.com/tracel-ai/cubecl?rev=3beb9afaa0acf2d3f7b2dfff4ebf6dedfb316825#3beb9afaa0acf2d3f7b2dfff4ebf6dedfb316825"
 dependencies = [
  "async-channel",
  "bytemuck",
@@ -1568,7 +1568,7 @@ dependencies = [
 [[package]]
 name = "cubecl-zspace"
 version = "0.11.0-pre.1"
-source = "git+https://github.com/tracel-ai/cubecl?rev=945cce851dd7d0614e127fbf9a63e767c04ebdda#945cce851dd7d0614e127fbf9a63e767c04ebdda"
+source = "git+https://github.com/tracel-ai/cubecl?rev=3beb9afaa0acf2d3f7b2dfff4ebf6dedfb316825#3beb9afaa0acf2d3f7b2dfff4ebf6dedfb316825"
 dependencies = [
  "derive-new",
  "serde",
@@ -1578,7 +1578,7 @@ dependencies = [
 [[package]]
 name = "cubek"
 version = "0.3.0-pre.1"
-source = "git+https://github.com/tracel-ai/cubek?rev=fb2ddf234cb71e4012c27a3f82291932f15ca0a0#fb2ddf234cb71e4012c27a3f82291932f15ca0a0"
+source = "git+https://github.com/tracel-ai/cubek?rev=3ec66d7fcfc8a9ca91961300104b6a32046c284e#3ec66d7fcfc8a9ca91961300104b6a32046c284e"
 dependencies = [
  "cubecl",
  "cubek-attention",
@@ -1596,7 +1596,7 @@ dependencies = [
 [[package]]
 name = "cubek-attention"
 version = "0.3.0-pre.1"
-source = "git+https://github.com/tracel-ai/cubek?rev=fb2ddf234cb71e4012c27a3f82291932f15ca0a0#fb2ddf234cb71e4012c27a3f82291932f15ca0a0"
+source = "git+https://github.com/tracel-ai/cubek?rev=3ec66d7fcfc8a9ca91961300104b6a32046c284e#3ec66d7fcfc8a9ca91961300104b6a32046c284e"
 dependencies = [
  "bytemuck",
  "cubecl",
@@ -1610,7 +1610,7 @@ dependencies = [
 [[package]]
 name = "cubek-convolution"
 version = "0.3.0-pre.1"
-source = "git+https://github.com/tracel-ai/cubek?rev=fb2ddf234cb71e4012c27a3f82291932f15ca0a0#fb2ddf234cb71e4012c27a3f82291932f15ca0a0"
+source = "git+https://github.com/tracel-ai/cubek?rev=3ec66d7fcfc8a9ca91961300104b6a32046c284e#3ec66d7fcfc8a9ca91961300104b6a32046c284e"
 dependencies = [
  "bytemuck",
  "cubecl",
@@ -1626,7 +1626,7 @@ dependencies = [
 [[package]]
 name = "cubek-fft"
 version = "0.3.0-pre.1"
-source = "git+https://github.com/tracel-ai/cubek?rev=fb2ddf234cb71e4012c27a3f82291932f15ca0a0#fb2ddf234cb71e4012c27a3f82291932f15ca0a0"
+source = "git+https://github.com/tracel-ai/cubek?rev=3ec66d7fcfc8a9ca91961300104b6a32046c284e#3ec66d7fcfc8a9ca91961300104b6a32046c284e"
 dependencies = [
  "cubecl",
 ]
@@ -1634,7 +1634,7 @@ dependencies = [
 [[package]]
 name = "cubek-interpolate"
 version = "0.3.0-pre.1"
-source = "git+https://github.com/tracel-ai/cubek?rev=fb2ddf234cb71e4012c27a3f82291932f15ca0a0#fb2ddf234cb71e4012c27a3f82291932f15ca0a0"
+source = "git+https://github.com/tracel-ai/cubek?rev=3ec66d7fcfc8a9ca91961300104b6a32046c284e#3ec66d7fcfc8a9ca91961300104b6a32046c284e"
 dependencies = [
  "cubecl",
  "cubecl-common",
@@ -1646,7 +1646,7 @@ dependencies = [
 [[package]]
 name = "cubek-layout"
 version = "0.3.0-pre.1"
-source = "git+https://github.com/tracel-ai/cubek?rev=fb2ddf234cb71e4012c27a3f82291932f15ca0a0#fb2ddf234cb71e4012c27a3f82291932f15ca0a0"
+source = "git+https://github.com/tracel-ai/cubek?rev=3ec66d7fcfc8a9ca91961300104b6a32046c284e#3ec66d7fcfc8a9ca91961300104b6a32046c284e"
 dependencies = [
  "cubecl",
 ]
@@ -1654,7 +1654,7 @@ dependencies = [
 [[package]]
 name = "cubek-matmul"
 version = "0.3.0-pre.1"
-source = "git+https://github.com/tracel-ai/cubek?rev=fb2ddf234cb71e4012c27a3f82291932f15ca0a0#fb2ddf234cb71e4012c27a3f82291932f15ca0a0"
+source = "git+https://github.com/tracel-ai/cubek?rev=3ec66d7fcfc8a9ca91961300104b6a32046c284e#3ec66d7fcfc8a9ca91961300104b6a32046c284e"
 dependencies = [
  "bytemuck",
  "cubecl",
@@ -1668,7 +1668,7 @@ dependencies = [
 [[package]]
 name = "cubek-pool"
 version = "0.3.0-pre.1"
-source = "git+https://github.com/tracel-ai/cubek?rev=fb2ddf234cb71e4012c27a3f82291932f15ca0a0#fb2ddf234cb71e4012c27a3f82291932f15ca0a0"
+source = "git+https://github.com/tracel-ai/cubek?rev=3ec66d7fcfc8a9ca91961300104b6a32046c284e#3ec66d7fcfc8a9ca91961300104b6a32046c284e"
 dependencies = [
  "cubecl",
  "cubecl-common",
@@ -1678,7 +1678,7 @@ dependencies = [
 [[package]]
 name = "cubek-quant"
 version = "0.3.0-pre.1"
-source = "git+https://github.com/tracel-ai/cubek?rev=fb2ddf234cb71e4012c27a3f82291932f15ca0a0#fb2ddf234cb71e4012c27a3f82291932f15ca0a0"
+source = "git+https://github.com/tracel-ai/cubek?rev=3ec66d7fcfc8a9ca91961300104b6a32046c284e#3ec66d7fcfc8a9ca91961300104b6a32046c284e"
 dependencies = [
  "cubecl",
  "cubecl-common",
@@ -1690,7 +1690,7 @@ dependencies = [
 [[package]]
 name = "cubek-random"
 version = "0.3.0-pre.1"
-source = "git+https://github.com/tracel-ai/cubek?rev=fb2ddf234cb71e4012c27a3f82291932f15ca0a0#fb2ddf234cb71e4012c27a3f82291932f15ca0a0"
+source = "git+https://github.com/tracel-ai/cubek?rev=3ec66d7fcfc8a9ca91961300104b6a32046c284e#3ec66d7fcfc8a9ca91961300104b6a32046c284e"
 dependencies = [
  "cubecl",
  "cubecl-common",
@@ -1703,7 +1703,7 @@ dependencies = [
 [[package]]
 name = "cubek-reduce"
 version = "0.3.0-pre.1"
-source = "git+https://github.com/tracel-ai/cubek?rev=fb2ddf234cb71e4012c27a3f82291932f15ca0a0#fb2ddf234cb71e4012c27a3f82291932f15ca0a0"
+source = "git+https://github.com/tracel-ai/cubek?rev=3ec66d7fcfc8a9ca91961300104b6a32046c284e#3ec66d7fcfc8a9ca91961300104b6a32046c284e"
 dependencies = [
  "cubecl",
  "cubek-layout",
@@ -1717,7 +1717,7 @@ dependencies = [
 [[package]]
 name = "cubek-std"
 version = "0.3.0-pre.1"
-source = "git+https://github.com/tracel-ai/cubek?rev=fb2ddf234cb71e4012c27a3f82291932f15ca0a0#fb2ddf234cb71e4012c27a3f82291932f15ca0a0"
+source = "git+https://github.com/tracel-ai/cubek?rev=3ec66d7fcfc8a9ca91961300104b6a32046c284e#3ec66d7fcfc8a9ca91961300104b6a32046c284e"
 dependencies = [
  "cubecl",
  "cubecl-common",
@@ -1727,7 +1727,7 @@ dependencies = [
 [[package]]
 name = "cubek-tile"
 version = "0.3.0-pre.1"
-source = "git+https://github.com/tracel-ai/cubek?rev=fb2ddf234cb71e4012c27a3f82291932f15ca0a0#fb2ddf234cb71e4012c27a3f82291932f15ca0a0"
+source = "git+https://github.com/tracel-ai/cubek?rev=3ec66d7fcfc8a9ca91961300104b6a32046c284e#3ec66d7fcfc8a9ca91961300104b6a32046c284e"
 dependencies = [
  "bytemuck",
  "cubecl",

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -18,7 +18,7 @@ keywords = ["tracel", "burn-central", "burn", "sdk"]
 categories = ["development-tools"]
 
 [workspace.dependencies]
-burn = { git = "https://github.com/tracel-ai/burn", rev = "862ef266ade864d6fc48df3687e9f8b911c7d05e", default-features = false, features = [
+burn = { path = "../burn/crates/burn", default-features = false, features = [
     "train",
 ] }
 

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -18,7 +18,7 @@ keywords = ["tracel", "burn-central", "burn", "sdk"]
 categories = ["development-tools"]
 
 [workspace.dependencies]
-burn = { path = "../burn/crates/burn", default-features = false, features = [
+burn = { git = "https://github.com/tracel-ai/burn", rev = "44605a412c0dd1b17b31ecb890cf1d3d474e5516", default-features = false, features = [
     "train",
 ] }
 

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -18,7 +18,7 @@ keywords = ["tracel", "burn-central", "burn", "sdk"]
 categories = ["development-tools"]
 
 [workspace.dependencies]
-burn = { git = "https://github.com/tracel-ai/burn", rev = "44605a412c0dd1b17b31ecb890cf1d3d474e5516", default-features = false, features = [
+burn = { git = "https://github.com/tracel-ai/burn", rev = "35ff68bd3b2faa6b6f651e5d7ab5939b4504f799", default-features = false, features = [
     "train",
 ] }
 

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -18,7 +18,7 @@ keywords = ["tracel", "burn-central", "burn", "sdk"]
 categories = ["development-tools"]
 
 [workspace.dependencies]
-burn = { git = "https://github.com/tracel-ai/burn", rev = "1b6dd60361115a0efb5b67c43cb75cd856b30498", default-features = false, features = [
+burn = { git = "https://github.com/tracel-ai/burn", rev = "862ef266ade864d6fc48df3687e9f8b911c7d05e", default-features = false, features = [
     "train",
 ] }
 

--- a/crates/tracel-core/src/experiment/remote/cloud/artifacts.rs
+++ b/crates/tracel-core/src/experiment/remote/cloud/artifacts.rs
@@ -10,18 +10,18 @@ use crate::experiment::remote::session::{ArtifactUploadError, ArtifactUploader};
 
 use super::{ExperimentArtifactClient, ExperimentPath};
 
-pub struct ConsoleArtifactReader {
+pub struct CloudArtifactReader {
     client: Client,
     exp_path: ExperimentPath,
 }
 
-impl ConsoleArtifactReader {
+impl CloudArtifactReader {
     pub fn new(client: Client, exp_path: ExperimentPath) -> Self {
         Self { client, exp_path }
     }
 }
 
-impl ExperimentArtifactReader for ConsoleArtifactReader {
+impl ExperimentArtifactReader for CloudArtifactReader {
     fn load_artifact_raw(
         &self,
         experiment_id: ExperimentId,
@@ -58,11 +58,11 @@ impl ExperimentArtifactReader for ConsoleArtifactReader {
     }
 }
 
-pub struct ConsoleArtifactUploader {
+pub struct CloudArtifactUploader {
     client: ExperimentArtifactClient,
 }
 
-impl ConsoleArtifactUploader {
+impl CloudArtifactUploader {
     pub fn new(client: Client, exp_path: ExperimentPath) -> Self {
         Self {
             client: ExperimentArtifactClient::new(client, exp_path),
@@ -70,7 +70,7 @@ impl ConsoleArtifactUploader {
     }
 }
 
-impl ArtifactUploader for ConsoleArtifactUploader {
+impl ArtifactUploader for CloudArtifactUploader {
     fn upload(
         &self,
         name: &str,

--- a/crates/tracel-core/src/experiment/remote/cloud/artifacts.rs
+++ b/crates/tracel-core/src/experiment/remote/cloud/artifacts.rs
@@ -37,7 +37,6 @@ impl ExperimentArtifactReader for ConsoleArtifactReader {
             num,
         );
         let scope = ExperimentArtifactClient::new(self.client.clone(), experiment_path);
-
         let artifact = scope.fetch(name).map_err(|err| {
             ExperimentReaderError::with_source("Failed to resolve experiment artifact", err)
         })?;

--- a/crates/tracel-core/src/experiment/remote/cloud/artifacts.rs
+++ b/crates/tracel-core/src/experiment/remote/cloud/artifacts.rs
@@ -37,6 +37,7 @@ impl ExperimentArtifactReader for ConsoleArtifactReader {
             num,
         );
         let scope = ExperimentArtifactClient::new(self.client.clone(), experiment_path);
+
         let artifact = scope.fetch(name).map_err(|err| {
             ExperimentReaderError::with_source("Failed to resolve experiment artifact", err)
         })?;

--- a/crates/tracel-core/src/experiment/remote/cloud/logs.rs
+++ b/crates/tracel-core/src/experiment/remote/cloud/logs.rs
@@ -14,13 +14,13 @@ use crate::experiment::remote::log_store::{LogStoreError, LogUploader};
 
 use super::ExperimentPath;
 
-pub struct ConsoleLogUploader {
+pub struct CloudLogUploader {
     artifact_id: Option<String>,
     client: Client,
     experiment_path: ExperimentPath,
 }
 
-impl ConsoleLogUploader {
+impl CloudLogUploader {
     pub fn new(client: Client, experiment_path: ExperimentPath) -> Self {
         Self {
             artifact_id: None,
@@ -30,7 +30,7 @@ impl ConsoleLogUploader {
     }
 }
 
-impl LogUploader for ConsoleLogUploader {
+impl LogUploader for CloudLogUploader {
     fn upload(&mut self, bundle: InMemoryBundleSources) -> Result<(), LogStoreError> {
         let mut specs = Vec::with_capacity(bundle.files().len());
         for file in bundle.files() {

--- a/crates/tracel-core/src/experiment/remote/cloud/mod.rs
+++ b/crates/tracel-core/src/experiment/remote/cloud/mod.rs
@@ -14,8 +14,8 @@ use tracel_artifact::upload::{
 mod artifacts;
 mod logs;
 
-pub use artifacts::{ConsoleArtifactReader, ConsoleArtifactUploader};
-pub use logs::ConsoleLogUploader;
+pub use artifacts::{CloudArtifactReader, CloudArtifactUploader};
+pub use logs::CloudLogUploader;
 
 use tracel_experiment::ArtifactKind;
 use tracel_experiment::error::{ExperimentError, ExperimentErrorKind};
@@ -274,8 +274,8 @@ fn create_run(
     let path = ExperimentPath::new(namespace, project_name, experiment_num);
     let cancel_token = CancelToken::new();
 
-    let log_uploader = ConsoleLogUploader::new(client.clone(), path.clone());
-    let artifact_uploader = ConsoleArtifactUploader::new(client.clone(), path.clone());
+    let log_uploader = CloudLogUploader::new(client.clone(), path.clone());
+    let artifact_uploader = CloudArtifactUploader::new(client.clone(), path.clone());
 
     let ws = client.create_experiment_run_websocket(namespace, project_name, experiment_num)?;
 
@@ -286,7 +286,7 @@ fn create_run(
         cancel_token.clone(),
     );
 
-    let reader = ConsoleArtifactReader::new(client, path);
+    let reader = CloudArtifactReader::new(client, path);
     let id = ExperimentId::from(format!("{}", experiment_num));
 
     Ok(ExperimentRun::new(id, session, reader, cancel_token))

--- a/crates/tracel-experiment/src/integration/training/checkpoint.rs
+++ b/crates/tracel-experiment/src/integration/training/checkpoint.rs
@@ -11,18 +11,6 @@ use serde::Deserialize;
 use serde::Serialize;
 use tracel_artifact::bundle::{BundleDecode, BundleEncode, BundleSink, BundleSource};
 
-#[derive(thiserror::Error, Debug)]
-pub enum ExperimentCheckpointError {
-    #[error("File name should be a valid string")]
-    InvalidFileName,
-
-    #[error("File name should be present")]
-    MissingFileName,
-
-    #[error("{0} items directly is not supported by ExperimentCheckpointRecorder")]
-    NotSupported(String),
-}
-
 struct CheckpointRecordSources<C: Checkpoint> {
     pub record: C,
 }

--- a/crates/tracel-experiment/src/integration/training/checkpoint.rs
+++ b/crates/tracel-experiment/src/integration/training/checkpoint.rs
@@ -11,12 +11,12 @@ use serde::Serialize;
 use tracel_artifact::bundle::{BundleDecode, BundleEncode, BundleSink, BundleSource};
 
 struct CheckpointRecordSources<C: Checkpoint> {
-    pub record: C,
+    pub checkpoint: C,
 }
 
 impl<C: Checkpoint> CheckpointRecordSources<C> {
-    pub fn new(record: C) -> Self {
-        Self { record }
+    pub fn new(checkpoint: C) -> Self {
+        Self { checkpoint }
     }
 }
 
@@ -42,7 +42,7 @@ impl<C: Checkpoint> BundleEncode for CheckpointRecordSources<C> {
         settings: &Self::Settings,
     ) -> Result<(), Self::Error> {
         let bytes = self
-            .record
+            .checkpoint
             .checkpoint_into_bytes()
             .map_err(|e| format!("Failed to record to bytes: {}", e))?;
 
@@ -126,7 +126,7 @@ impl<C: Checkpoint> Checkpointer<C> for ExperimentCheckpointer {
         };
         self.experiment_handle
             .save_artifact(
-                self.file_name.clone(),
+                self.path_for_epoch(epoch),
                 ArtifactKind::Other,
                 CheckpointRecordSources::new(record),
                 &settings,
@@ -150,10 +150,10 @@ impl<C: Checkpoint> Checkpointer<C> for ExperimentCheckpointer {
             .experiment_handle
             .use_artifact::<CheckpointRecordSources<C>>(
                 self.experiment_handle.id().clone(),
-                self.file_name.clone(),
+                self.path_for_epoch(epoch),
                 &settings,
             )
             .map_err(|e| CheckpointerError::Unknown(format!("Failed to load artifact: {e}")))?;
-        Ok(artifact.record)
+        Ok(artifact.checkpoint)
     }
 }

--- a/crates/tracel-experiment/src/integration/training/checkpoint.rs
+++ b/crates/tracel-experiment/src/integration/training/checkpoint.rs
@@ -2,7 +2,6 @@ use burn::train::checkpoint::Checkpoint;
 use burn::train::checkpoint::Checkpointer;
 use burn::train::checkpoint::CheckpointerError;
 use std::fmt;
-use thiserror;
 
 use crate::ArtifactKind;
 use crate::ExperimentRunHandle;

--- a/crates/tracel-experiment/src/integration/training/checkpoint.rs
+++ b/crates/tracel-experiment/src/integration/training/checkpoint.rs
@@ -1,14 +1,11 @@
 use burn::train::checkpoint::Checkpoint;
 use burn::train::checkpoint::Checkpointer;
 use burn::train::checkpoint::CheckpointerError;
-use std::any::Any;
 use std::fmt;
-use std::path::PathBuf;
 use thiserror;
 
 use crate::ArtifactKind;
 use crate::ExperimentRunHandle;
-use burn::store::ModuleRecord;
 use burn::tensor::Bytes;
 use serde::Deserialize;
 use serde::Serialize;
@@ -26,12 +23,12 @@ pub enum ExperimentCheckpointError {
     NotSupported(String),
 }
 
-struct CheckpointRecordSources {
-    pub record: Box<dyn Any>,
+struct CheckpointRecordSources<C: Checkpoint> {
+    pub record: C,
 }
 
-impl CheckpointRecordSources {
-    pub fn new(record: Box<dyn Any>) -> Self {
+impl<C: Checkpoint> CheckpointRecordSources<C> {
+    pub fn new(record: C) -> Self {
         Self { record }
     }
 }
@@ -49,7 +46,7 @@ impl Default for CheckpointRecordArtifactSettings {
     }
 }
 
-impl BundleEncode for CheckpointRecordSources {
+impl<C: Checkpoint> BundleEncode for CheckpointRecordSources<C> {
     type Settings = CheckpointRecordArtifactSettings;
     type Error = String;
     fn encode<E: BundleSink>(
@@ -59,9 +56,7 @@ impl BundleEncode for CheckpointRecordSources {
     ) -> Result<(), Self::Error> {
         let bytes = self
             .record
-            .downcast::<ModuleRecord>()
-            .expect("Should be a ModuleRecord")
-            .into_bytes()
+            .checkpoint_into_bytes()
             .map_err(|e| format!("Failed to record to bytes: {}", e))?;
 
         sink.put_bytes(&settings.name, &bytes)
@@ -70,7 +65,7 @@ impl BundleEncode for CheckpointRecordSources {
     }
 }
 
-impl BundleDecode for CheckpointRecordSources {
+impl<C: Checkpoint> BundleDecode for CheckpointRecordSources<C> {
     type Settings = CheckpointRecordArtifactSettings;
     type Error = String;
 
@@ -88,9 +83,9 @@ impl BundleDecode for CheckpointRecordSources {
                 settings.name, e
             )
         })?;
-        let record = ModuleRecord::from_bytes(Bytes::from_bytes_vec(bytes))
+        let record = C::checkpoint_from_bytes(Bytes::from_bytes_vec(bytes))
             .map_err(|e| format!("Failed to load record from bytes: {}", e))?;
-        Ok(Self::new(Box::new(record)))
+        Ok(Self::new(record))
     }
 }
 
@@ -113,28 +108,17 @@ impl fmt::Debug for ExperimentCheckpointer {
 
 impl ExperimentCheckpointer {
     /// Create a recorder backed by the provided experiment run.
-    pub fn try_new(
-        experiment: impl Into<ExperimentRunHandle>,
-        path: PathBuf,
-    ) -> Result<Self, ExperimentCheckpointError> {
-        let file_name = path
-            .file_name()
-            .ok_or(ExperimentCheckpointError::MissingFileName)?
-            .to_str()
-            .ok_or(ExperimentCheckpointError::InvalidFileName)?
-            .to_string();
-        Ok(Self {
+    pub fn new(experiment: impl Into<ExperimentRunHandle>, file_name: String) -> Self {
+        Self {
             experiment_handle: experiment.into(),
             file_name,
-        })
+        }
+    }
+
+    fn path_for_epoch(&self, epoch: usize) -> String {
+        format!("{}-{}.bpk", self.file_name, epoch)
     }
 }
-
-// impl FileRecorder for ExperimentCheckpointRecorder {
-//     fn file_extension() -> &'static str {
-//         "mpk"
-//     }
-// }
 
 impl Default for ExperimentCheckpointer {
     fn default() -> Self {
@@ -147,17 +131,17 @@ impl Default for ExperimentCheckpointer {
 impl<C: Checkpoint> Checkpointer<C> for ExperimentCheckpointer {
     fn save(
         &self,
-        _epoch: usize,
+        epoch: usize,
         record: C,
     ) -> Result<(), burn::train::checkpoint::CheckpointerError> {
         let settings = CheckpointRecordArtifactSettings {
-            name: self.file_name.clone(),
+            name: self.path_for_epoch(epoch),
         };
         self.experiment_handle
             .save_artifact(
                 self.file_name.clone(),
                 ArtifactKind::Other,
-                CheckpointRecordSources::new(Box::new(record)),
+                CheckpointRecordSources::new(record),
                 &settings,
             )
             .map_err(|e| {
@@ -171,18 +155,18 @@ impl<C: Checkpoint> Checkpointer<C> for ExperimentCheckpointer {
         Ok(())
     }
 
-    fn restore(&self, _epoch: usize) -> Result<C, burn::train::checkpoint::CheckpointerError> {
+    fn restore(&self, epoch: usize) -> Result<C, burn::train::checkpoint::CheckpointerError> {
         let settings = CheckpointRecordArtifactSettings {
-            name: self.file_name.clone(),
+            name: self.path_for_epoch(epoch),
         };
         let artifact = self
             .experiment_handle
-            .use_artifact::<CheckpointRecordSources>(
+            .use_artifact::<CheckpointRecordSources<C>>(
                 self.experiment_handle.id().clone(),
                 self.file_name.clone(),
                 &settings,
             )
             .map_err(|e| CheckpointerError::Unknown(format!("Failed to load artifact: {e}")))?;
-        Ok(*artifact.record.downcast::<C>().expect(""))
+        Ok(artifact.record)
     }
 }

--- a/crates/tracel-experiment/src/integration/training/checkpoint.rs
+++ b/crates/tracel-experiment/src/integration/training/checkpoint.rs
@@ -102,7 +102,7 @@ impl ExperimentCheckpointer {
         }
     }
 
-    fn path_for_epoch(&self, epoch: usize) -> String {
+    fn full_path_name(&self, epoch: usize) -> String {
         format!("{}-{}.bpk", self.file_name, epoch)
     }
 }
@@ -122,11 +122,11 @@ impl<C: Checkpoint> Checkpointer<C> for ExperimentCheckpointer {
         record: C,
     ) -> Result<(), burn::train::checkpoint::CheckpointerError> {
         let settings = CheckpointRecordArtifactSettings {
-            name: self.path_for_epoch(epoch),
+            name: self.full_path_name(epoch),
         };
         self.experiment_handle
             .save_artifact(
-                self.path_for_epoch(epoch),
+                self.full_path_name(epoch),
                 ArtifactKind::Other,
                 CheckpointRecordSources::new(record),
                 &settings,
@@ -144,13 +144,13 @@ impl<C: Checkpoint> Checkpointer<C> for ExperimentCheckpointer {
 
     fn restore(&self, epoch: usize) -> Result<C, burn::train::checkpoint::CheckpointerError> {
         let settings = CheckpointRecordArtifactSettings {
-            name: self.path_for_epoch(epoch),
+            name: self.full_path_name(epoch),
         };
         let artifact = self
             .experiment_handle
             .use_artifact::<CheckpointRecordSources<C>>(
                 self.experiment_handle.id().clone(),
-                self.path_for_epoch(epoch),
+                self.full_path_name(epoch),
                 &settings,
             )
             .map_err(|e| CheckpointerError::Unknown(format!("Failed to load artifact: {e}")))?;

--- a/crates/tracel-experiment/src/integration/training/checkpoint.rs
+++ b/crates/tracel-experiment/src/integration/training/checkpoint.rs
@@ -4,6 +4,7 @@ use burn::train::checkpoint::CheckpointerError;
 use std::fmt;
 
 use crate::ArtifactKind;
+use crate::ExperimentId;
 use crate::ExperimentRunHandle;
 use burn::tensor::Bytes;
 use serde::Deserialize;
@@ -76,30 +77,42 @@ impl<C: Checkpoint> BundleDecode for CheckpointRecordSources<C> {
     }
 }
 
-/// Experiment-backed implementation of Burn's [`Recorder`] and [`FileRecorder`] traits.
+/// Experiment-backed implementation of Burn's [`Checkpointer`] trait.
 ///
-/// Prefer [`crate::integration::training::ExperimentTrainingExt::checkpoint_recorder`] when you
+/// Prefer [`crate::integration::training::ExperimentTrainingExt::checkpointers`] when you
 /// already have an [`ExperimentRun`][crate::ExperimentRun] in scope.
 #[derive(Clone)]
 pub struct ExperimentCheckpointer {
     experiment_handle: ExperimentRunHandle,
     file_name: String,
+    restore_from: Option<ExperimentId>,
 }
 
 impl fmt::Debug for ExperimentCheckpointer {
     fn fmt(&self, f: &mut fmt::Formatter<'_>) -> fmt::Result {
-        f.debug_struct("ExperimentCheckpointRecorder")
+        f.debug_struct("ExperimentCheckpointer")
             .finish_non_exhaustive()
     }
 }
 
 impl ExperimentCheckpointer {
-    /// Create a recorder backed by the provided experiment run.
+    /// Create a checkpointer backed by the provided experiment run.
     pub fn new(experiment: impl Into<ExperimentRunHandle>, file_name: String) -> Self {
         Self {
             experiment_handle: experiment.into(),
             file_name,
+            restore_from: None,
         }
+    }
+
+    /// Set a source experiment to restore checkpoints from.
+    ///
+    /// When set, `restore` loads artifacts from the given experiment instead of
+    /// the current one. This is needed when resuming training across runs, since
+    /// each run creates a new experiment that starts with no artifacts.
+    pub fn with_restore_from(mut self, experiment_id: impl Into<ExperimentId>) -> Self {
+        self.restore_from = Some(experiment_id.into());
+        self
     }
 
     fn full_path_name(&self, epoch: usize) -> String {
@@ -110,7 +123,7 @@ impl ExperimentCheckpointer {
 impl Default for ExperimentCheckpointer {
     fn default() -> Self {
         unimplemented!(
-            "Default is not implemented for ExperimentCheckpointRecorder, as it requires an experiment run."
+            "Default is not implemented for ExperimentCheckpointer, as it requires an experiment run."
         )
     }
 }
@@ -146,10 +159,14 @@ impl<C: Checkpoint> Checkpointer<C> for ExperimentCheckpointer {
         let settings = CheckpointRecordArtifactSettings {
             name: self.full_path_name(epoch),
         };
+        let source_id = self
+            .restore_from
+            .clone()
+            .unwrap_or_else(|| self.experiment_handle.id().clone());
         let artifact = self
             .experiment_handle
             .use_artifact::<CheckpointRecordSources<C>>(
-                self.experiment_handle.id().clone(),
+                source_id,
                 self.full_path_name(epoch),
                 &settings,
             )

--- a/crates/tracel-experiment/src/integration/training/checkpoint.rs
+++ b/crates/tracel-experiment/src/integration/training/checkpoint.rs
@@ -1,22 +1,37 @@
+use burn::train::checkpoint::Checkpoint;
+use burn::train::checkpoint::Checkpointer;
+use burn::train::checkpoint::CheckpointerError;
+use std::any::Any;
 use std::fmt;
 use std::path::PathBuf;
+use thiserror;
 
 use crate::ArtifactKind;
 use crate::ExperimentRunHandle;
-use burn::record::{
-    FileRecorder, FullPrecisionSettings, NamedMpkBytesRecorder, Record, Recorder, RecorderError,
-};
-use burn::tensor::Device;
+use burn::store::ModuleRecord;
+use burn::tensor::Bytes;
 use serde::Deserialize;
-use serde::{Serialize, de::DeserializeOwned};
+use serde::Serialize;
 use tracel_artifact::bundle::{BundleDecode, BundleEncode, BundleSink, BundleSource};
 
-struct CheckpointRecordSources<R> {
-    pub record: R,
+#[derive(thiserror::Error, Debug)]
+pub enum ExperimentCheckpointError {
+    #[error("File name should be a valid string")]
+    InvalidFileName,
+
+    #[error("File name should be present")]
+    MissingFileName,
+
+    #[error("{0} items directly is not supported by ExperimentCheckpointRecorder")]
+    NotSupported(String),
 }
 
-impl<R> CheckpointRecordSources<R> {
-    pub fn new(record: R) -> Self {
+struct CheckpointRecordSources {
+    pub record: Box<dyn Any>,
+}
+
+impl CheckpointRecordSources {
+    pub fn new(record: Box<dyn Any>) -> Self {
         Self { record }
     }
 }
@@ -34,10 +49,7 @@ impl Default for CheckpointRecordArtifactSettings {
     }
 }
 
-impl<R> BundleEncode for CheckpointRecordSources<R>
-where
-    R: Record,
-{
+impl BundleEncode for CheckpointRecordSources {
     type Settings = CheckpointRecordArtifactSettings;
     type Error = String;
     fn encode<E: BundleSink>(
@@ -45,20 +57,20 @@ where
         sink: &mut E,
         settings: &Self::Settings,
     ) -> Result<(), Self::Error> {
-        let recorder = NamedMpkBytesRecorder::<FullPrecisionSettings>::default();
-        let bytes = recorder
-            .record(self.record, ())
+        let bytes = self
+            .record
+            .downcast::<ModuleRecord>()
+            .expect("Should be a ModuleRecord")
+            .into_bytes()
             .map_err(|e| format!("Failed to record to bytes: {}", e))?;
+
         sink.put_bytes(&settings.name, &bytes)
             .map_err(|e| format!("Failed to write bytes to sink: {}", e))?;
         Ok(())
     }
 }
 
-impl<R> BundleDecode for CheckpointRecordSources<R>
-where
-    R: Record,
-{
+impl BundleDecode for CheckpointRecordSources {
     type Settings = CheckpointRecordArtifactSettings;
     type Error = String;
 
@@ -76,11 +88,9 @@ where
                 settings.name, e
             )
         })?;
-        let recorder = NamedMpkBytesRecorder::<FullPrecisionSettings>::default();
-        let record = recorder
-            .load::<R>(bytes, &Device::default())
+        let record = ModuleRecord::from_bytes(Bytes::from_bytes_vec(bytes))
             .map_err(|e| format!("Failed to load record from bytes: {}", e))?;
-        Ok(Self::new(record))
+        Ok(Self::new(Box::new(record)))
     }
 }
 
@@ -89,33 +99,44 @@ where
 /// Prefer [`crate::integration::training::ExperimentTrainingExt::checkpoint_recorder`] when you
 /// already have an [`ExperimentRun`][crate::ExperimentRun] in scope.
 #[derive(Clone)]
-pub struct ExperimentCheckpointRecorder {
+pub struct ExperimentCheckpointer {
     experiment_handle: ExperimentRunHandle,
+    file_name: String,
 }
 
-impl fmt::Debug for ExperimentCheckpointRecorder {
+impl fmt::Debug for ExperimentCheckpointer {
     fn fmt(&self, f: &mut fmt::Formatter<'_>) -> fmt::Result {
         f.debug_struct("ExperimentCheckpointRecorder")
             .finish_non_exhaustive()
     }
 }
 
-impl ExperimentCheckpointRecorder {
+impl ExperimentCheckpointer {
     /// Create a recorder backed by the provided experiment run.
-    pub fn new(experiment: impl Into<ExperimentRunHandle>) -> Self {
-        Self {
+    pub fn try_new(
+        experiment: impl Into<ExperimentRunHandle>,
+        path: PathBuf,
+    ) -> Result<Self, ExperimentCheckpointError> {
+        let file_name = path
+            .file_name()
+            .ok_or(ExperimentCheckpointError::MissingFileName)?
+            .to_str()
+            .ok_or(ExperimentCheckpointError::InvalidFileName)?
+            .to_string();
+        Ok(Self {
             experiment_handle: experiment.into(),
-        }
+            file_name,
+        })
     }
 }
 
-impl FileRecorder for ExperimentCheckpointRecorder {
-    fn file_extension() -> &'static str {
-        "mpk"
-    }
-}
+// impl FileRecorder for ExperimentCheckpointRecorder {
+//     fn file_extension() -> &'static str {
+//         "mpk"
+//     }
+// }
 
-impl Default for ExperimentCheckpointRecorder {
+impl Default for ExperimentCheckpointer {
     fn default() -> Self {
         unimplemented!(
             "Default is not implemented for ExperimentCheckpointRecorder, as it requires an experiment run."
@@ -123,86 +144,45 @@ impl Default for ExperimentCheckpointRecorder {
     }
 }
 
-impl Recorder for ExperimentCheckpointRecorder {
-    type Settings = FullPrecisionSettings;
-    type RecordArgs = PathBuf;
-    type RecordOutput = ();
-    type LoadArgs = PathBuf;
-
-    fn record<R>(
+impl<C: Checkpoint> Checkpointer<C> for ExperimentCheckpointer {
+    fn save(
         &self,
-        record: R,
-        args: Self::RecordArgs,
-    ) -> Result<Self::RecordOutput, RecorderError>
-    where
-        R: Record,
-    {
-        let file_name = args
-            .file_name()
-            .ok_or(RecorderError::Unknown(
-                "File name should be present".to_string(),
-            ))?
-            .to_str()
-            .ok_or(RecorderError::Unknown(
-                "File name should be a valid string".to_string(),
-            ))?;
+        _epoch: usize,
+        record: C,
+    ) -> Result<(), burn::train::checkpoint::CheckpointerError> {
         let settings = CheckpointRecordArtifactSettings {
-            name: file_name.to_string(),
+            name: self.file_name.clone(),
         };
         self.experiment_handle
             .save_artifact(
-                file_name,
+                self.file_name.clone(),
                 ArtifactKind::Other,
-                CheckpointRecordSources::new(record),
+                CheckpointRecordSources::new(Box::new(record)),
                 &settings,
             )
-            .map_err(|e| RecorderError::Unknown(format!("Failed to record artifact: {e}")))
+            .map_err(|e| {
+                burn::train::checkpoint::CheckpointerError::Unknown(format!(
+                    "Failed to save artifact: {e}"
+                ))
+            })
     }
 
-    fn load<R>(&self, args: Self::LoadArgs, _device: &Device) -> Result<R, RecorderError>
-    where
-        R: Record,
-    {
-        let name = args
-            .file_name()
-            .ok_or(RecorderError::Unknown(
-                "File name should be present".to_string(),
-            ))?
-            .to_str()
-            .ok_or(RecorderError::Unknown(
-                "File name should be a valid string".to_string(),
-            ))?;
+    fn delete(&self, _epoch: usize) -> Result<(), burn::train::checkpoint::CheckpointerError> {
+        Ok(())
+    }
 
+    fn restore(&self, _epoch: usize) -> Result<C, burn::train::checkpoint::CheckpointerError> {
         let settings = CheckpointRecordArtifactSettings {
-            name: name.to_string(),
+            name: self.file_name.clone(),
         };
         let artifact = self
             .experiment_handle
-            .use_artifact::<CheckpointRecordSources<R>>(
+            .use_artifact::<CheckpointRecordSources>(
                 self.experiment_handle.id().clone(),
-                name,
+                self.file_name.clone(),
                 &settings,
             )
-            .map_err(|e| RecorderError::Unknown(format!("Failed to load artifact: {e}")))?;
-        Ok(artifact.record)
-    }
-
-    fn save_item<I: Serialize>(
-        &self,
-        _item: I,
-        _args: Self::RecordArgs,
-    ) -> Result<Self::RecordOutput, RecorderError> {
-        Err(RecorderError::Unknown(
-            "Saving items directly is not supported by ExperimentCheckpointRecorder".to_string(),
-        ))
-    }
-
-    fn load_item<I>(&self, _args: &mut Self::LoadArgs) -> Result<I, RecorderError>
-    where
-        I: DeserializeOwned,
-    {
-        Err(RecorderError::Unknown(
-            "Loading items directly is not supported by ExperimentCheckpointRecorder".to_string(),
-        ))
+            .map_err(|e| CheckpointerError::Unknown(format!("Failed to load artifact: {e}")))?;
+        Ok(*artifact.record.downcast::<C>().expect(""))
     }
 }

--- a/crates/tracel-experiment/src/integration/training/mod.rs
+++ b/crates/tracel-experiment/src/integration/training/mod.rs
@@ -30,6 +30,7 @@ pub use interrupter::experiment_interrupter;
 pub use metric::ExperimentMetricLogger;
 pub use progress::{ExperimentEvaluationProgressLogger, ExperimentTrainingProgressLogger};
 
+use crate::ExperimentId;
 use crate::ExperimentRun;
 
 /// Extension trait adding Burn `train` adapter constructors to [`ExperimentRun`].
@@ -40,6 +41,18 @@ pub trait ExperimentTrainingExt {
     /// Create the three checkpointers (model, optimizer, lr scheduler) for supervised training.
     fn checkpointers(
         &self,
+    ) -> (
+        ExperimentCheckpointer,
+        ExperimentCheckpointer,
+        ExperimentCheckpointer,
+    );
+
+    /// Create the three checkpointers configured to restore from a previous experiment.
+    ///
+    /// Saves still go to the current experiment, but `restore` loads from `source_id`.
+    fn checkpointers_from(
+        &self,
+        source_id: impl Into<ExperimentId>,
     ) -> (
         ExperimentCheckpointer,
         ExperimentCheckpointer,
@@ -75,6 +88,25 @@ impl ExperimentTrainingExt for ExperimentRun {
         )
     }
 
+    fn checkpointers_from(
+        &self,
+        source_id: impl Into<ExperimentId>,
+    ) -> (
+        ExperimentCheckpointer,
+        ExperimentCheckpointer,
+        ExperimentCheckpointer,
+    ) {
+        let id = source_id.into();
+        (
+            ExperimentCheckpointer::new(self, "model".to_string())
+                .with_restore_from(id.clone()),
+            ExperimentCheckpointer::new(self, "optim".to_string())
+                .with_restore_from(id.clone()),
+            ExperimentCheckpointer::new(self, "scheduler".to_string())
+                .with_restore_from(id),
+        )
+    }
+
     fn interrupter(&self) -> burn::train::Interrupter {
         experiment_interrupter(self)
     }
@@ -104,6 +136,25 @@ impl ExperimentTrainingExt for crate::ExperimentRunHandle {
             ExperimentCheckpointer::new(self.clone(), "model".to_string()),
             ExperimentCheckpointer::new(self.clone(), "optim".to_string()),
             ExperimentCheckpointer::new(self.clone(), "scheduler".to_string()),
+        )
+    }
+
+    fn checkpointers_from(
+        &self,
+        source_id: impl Into<ExperimentId>,
+    ) -> (
+        ExperimentCheckpointer,
+        ExperimentCheckpointer,
+        ExperimentCheckpointer,
+    ) {
+        let id = source_id.into();
+        (
+            ExperimentCheckpointer::new(self.clone(), "model".to_string())
+                .with_restore_from(id.clone()),
+            ExperimentCheckpointer::new(self.clone(), "optim".to_string())
+                .with_restore_from(id.clone()),
+            ExperimentCheckpointer::new(self.clone(), "scheduler".to_string())
+                .with_restore_from(id),
         )
     }
 

--- a/crates/tracel-experiment/src/integration/training/mod.rs
+++ b/crates/tracel-experiment/src/integration/training/mod.rs
@@ -25,12 +25,14 @@ mod interrupter;
 mod metric;
 mod progress;
 
-pub use checkpoint::ExperimentCheckpointRecorder;
+use std::path::PathBuf;
+
+pub use checkpoint::ExperimentCheckpointer;
 pub use interrupter::experiment_interrupter;
 pub use metric::ExperimentMetricLogger;
 pub use progress::{ExperimentEvaluationProgressLogger, ExperimentTrainingProgressLogger};
 
-use crate::ExperimentRun;
+use crate::{ExperimentRun, integration::training::checkpoint::ExperimentCheckpointError};
 
 /// Extension trait adding Burn `train` adapter constructors to [`ExperimentRun`].
 pub trait ExperimentTrainingExt {
@@ -38,7 +40,10 @@ pub trait ExperimentTrainingExt {
     fn metric_logger(&self) -> ExperimentMetricLogger;
 
     /// Create a new [`ExperimentCheckpointRecorder`] for this run.
-    fn checkpoint_recorder(&self) -> ExperimentCheckpointRecorder;
+    fn checkpoint_recorder(
+        &self,
+        path: PathBuf,
+    ) -> Result<ExperimentCheckpointer, ExperimentCheckpointError>;
 
     /// Create a new [`burn::train::Interrupter`] linked to this run's cancellation token.
     fn interrupter(&self) -> burn::train::Interrupter;
@@ -55,8 +60,11 @@ impl ExperimentTrainingExt for ExperimentRun {
         ExperimentMetricLogger::new(self)
     }
 
-    fn checkpoint_recorder(&self) -> ExperimentCheckpointRecorder {
-        ExperimentCheckpointRecorder::new(self)
+    fn checkpoint_recorder(
+        &self,
+        path: PathBuf,
+    ) -> Result<ExperimentCheckpointer, ExperimentCheckpointError> {
+        ExperimentCheckpointer::try_new(self, path)
     }
 
     fn interrupter(&self) -> burn::train::Interrupter {
@@ -77,8 +85,11 @@ impl ExperimentTrainingExt for crate::ExperimentRunHandle {
         ExperimentMetricLogger::new(self.clone())
     }
 
-    fn checkpoint_recorder(&self) -> ExperimentCheckpointRecorder {
-        ExperimentCheckpointRecorder::new(self.clone())
+    fn checkpoint_recorder(
+        &self,
+        path: PathBuf,
+    ) -> Result<ExperimentCheckpointer, ExperimentCheckpointError> {
+        ExperimentCheckpointer::try_new(self.clone(), path)
     }
 
     fn interrupter(&self) -> burn::train::Interrupter {

--- a/crates/tracel-experiment/src/integration/training/mod.rs
+++ b/crates/tracel-experiment/src/integration/training/mod.rs
@@ -25,14 +25,12 @@ mod interrupter;
 mod metric;
 mod progress;
 
-use std::path::PathBuf;
-
 pub use checkpoint::ExperimentCheckpointer;
 pub use interrupter::experiment_interrupter;
 pub use metric::ExperimentMetricLogger;
 pub use progress::{ExperimentEvaluationProgressLogger, ExperimentTrainingProgressLogger};
 
-use crate::{ExperimentRun, integration::training::checkpoint::ExperimentCheckpointError};
+use crate::ExperimentRun;
 
 /// Extension trait adding Burn `train` adapter constructors to [`ExperimentRun`].
 pub trait ExperimentTrainingExt {

--- a/crates/tracel-experiment/src/integration/training/mod.rs
+++ b/crates/tracel-experiment/src/integration/training/mod.rs
@@ -98,12 +98,9 @@ impl ExperimentTrainingExt for ExperimentRun {
     ) {
         let id = source_id.into();
         (
-            ExperimentCheckpointer::new(self, "model".to_string())
-                .with_restore_from(id.clone()),
-            ExperimentCheckpointer::new(self, "optim".to_string())
-                .with_restore_from(id.clone()),
-            ExperimentCheckpointer::new(self, "scheduler".to_string())
-                .with_restore_from(id),
+            ExperimentCheckpointer::new(self, "model".to_string()).with_restore_from(id.clone()),
+            ExperimentCheckpointer::new(self, "optim".to_string()).with_restore_from(id.clone()),
+            ExperimentCheckpointer::new(self, "scheduler".to_string()).with_restore_from(id),
         )
     }
 

--- a/crates/tracel-experiment/src/integration/training/mod.rs
+++ b/crates/tracel-experiment/src/integration/training/mod.rs
@@ -40,10 +40,7 @@ pub trait ExperimentTrainingExt {
     fn metric_logger(&self) -> ExperimentMetricLogger;
 
     /// Create a new [`ExperimentCheckpointRecorder`] for this run.
-    fn checkpoint_recorder(
-        &self,
-        path: PathBuf,
-    ) -> Result<ExperimentCheckpointer, ExperimentCheckpointError>;
+    fn checkpoint_recorder(&self, file_name: String) -> ExperimentCheckpointer;
 
     /// Create a new [`burn::train::Interrupter`] linked to this run's cancellation token.
     fn interrupter(&self) -> burn::train::Interrupter;
@@ -60,11 +57,8 @@ impl ExperimentTrainingExt for ExperimentRun {
         ExperimentMetricLogger::new(self)
     }
 
-    fn checkpoint_recorder(
-        &self,
-        path: PathBuf,
-    ) -> Result<ExperimentCheckpointer, ExperimentCheckpointError> {
-        ExperimentCheckpointer::try_new(self, path)
+    fn checkpoint_recorder(&self, file_name: String) -> ExperimentCheckpointer {
+        ExperimentCheckpointer::new(self, file_name)
     }
 
     fn interrupter(&self) -> burn::train::Interrupter {
@@ -85,11 +79,8 @@ impl ExperimentTrainingExt for crate::ExperimentRunHandle {
         ExperimentMetricLogger::new(self.clone())
     }
 
-    fn checkpoint_recorder(
-        &self,
-        path: PathBuf,
-    ) -> Result<ExperimentCheckpointer, ExperimentCheckpointError> {
-        ExperimentCheckpointer::try_new(self.clone(), path)
+    fn checkpoint_recorder(&self, file_name: String) -> ExperimentCheckpointer {
+        ExperimentCheckpointer::new(self.clone(), file_name)
     }
 
     fn interrupter(&self) -> burn::train::Interrupter {

--- a/crates/tracel-experiment/src/integration/training/mod.rs
+++ b/crates/tracel-experiment/src/integration/training/mod.rs
@@ -16,7 +16,7 @@
 //! let experiment = ExperimentRun::local("./runs").unwrap();
 //!
 //! let _metrics = experiment.metric_logger();
-//! let _checkpoints = experiment.checkpoint_recorder();
+//! let _checkpoints = experiment.checkpointers();
 //! let _interrupter = experiment.interrupter();
 //! ```
 
@@ -37,8 +37,17 @@ pub trait ExperimentTrainingExt {
     /// Create a new [`ExperimentMetricLogger`] for this run.
     fn metric_logger(&self) -> ExperimentMetricLogger;
 
-    /// Create a new [`ExperimentCheckpointRecorder`] for this run.
+    /// Create a new [`ExperimentCheckpointer`] for this run.
     fn checkpoint_recorder(&self, file_name: String) -> ExperimentCheckpointer;
+
+    /// Create the three checkpointers (model, optimizer, lr scheduler) for supervised training.
+    fn checkpointers(
+        &self,
+    ) -> (
+        ExperimentCheckpointer,
+        ExperimentCheckpointer,
+        ExperimentCheckpointer,
+    );
 
     /// Create a new [`burn::train::Interrupter`] linked to this run's cancellation token.
     fn interrupter(&self) -> burn::train::Interrupter;
@@ -57,6 +66,20 @@ impl ExperimentTrainingExt for ExperimentRun {
 
     fn checkpoint_recorder(&self, file_name: String) -> ExperimentCheckpointer {
         ExperimentCheckpointer::new(self, file_name)
+    }
+
+    fn checkpointers(
+        &self,
+    ) -> (
+        ExperimentCheckpointer,
+        ExperimentCheckpointer,
+        ExperimentCheckpointer,
+    ) {
+        (
+            self.checkpoint_recorder("model".to_string()),
+            self.checkpoint_recorder("optim".to_string()),
+            self.checkpoint_recorder("scheduler".to_string()),
+        )
     }
 
     fn interrupter(&self) -> burn::train::Interrupter {
@@ -79,6 +102,20 @@ impl ExperimentTrainingExt for crate::ExperimentRunHandle {
 
     fn checkpoint_recorder(&self, file_name: String) -> ExperimentCheckpointer {
         ExperimentCheckpointer::new(self.clone(), file_name)
+    }
+
+    fn checkpointers(
+        &self,
+    ) -> (
+        ExperimentCheckpointer,
+        ExperimentCheckpointer,
+        ExperimentCheckpointer,
+    ) {
+        (
+            self.checkpoint_recorder("model".to_string()),
+            self.checkpoint_recorder("optim".to_string()),
+            self.checkpoint_recorder("scheduler".to_string()),
+        )
     }
 
     fn interrupter(&self) -> burn::train::Interrupter {

--- a/crates/tracel-experiment/src/integration/training/mod.rs
+++ b/crates/tracel-experiment/src/integration/training/mod.rs
@@ -37,9 +37,6 @@ pub trait ExperimentTrainingExt {
     /// Create a new [`ExperimentMetricLogger`] for this run.
     fn metric_logger(&self) -> ExperimentMetricLogger;
 
-    /// Create a new [`ExperimentCheckpointer`] for this run.
-    fn checkpoint_recorder(&self, file_name: String) -> ExperimentCheckpointer;
-
     /// Create the three checkpointers (model, optimizer, lr scheduler) for supervised training.
     fn checkpointers(
         &self,
@@ -64,10 +61,6 @@ impl ExperimentTrainingExt for ExperimentRun {
         ExperimentMetricLogger::new(self)
     }
 
-    fn checkpoint_recorder(&self, file_name: String) -> ExperimentCheckpointer {
-        ExperimentCheckpointer::new(self, file_name)
-    }
-
     fn checkpointers(
         &self,
     ) -> (
@@ -76,9 +69,9 @@ impl ExperimentTrainingExt for ExperimentRun {
         ExperimentCheckpointer,
     ) {
         (
-            self.checkpoint_recorder("model".to_string()),
-            self.checkpoint_recorder("optim".to_string()),
-            self.checkpoint_recorder("scheduler".to_string()),
+            ExperimentCheckpointer::new(self, "model".to_string()),
+            ExperimentCheckpointer::new(self, "optim".to_string()),
+            ExperimentCheckpointer::new(self, "scheduler".to_string()),
         )
     }
 
@@ -100,10 +93,6 @@ impl ExperimentTrainingExt for crate::ExperimentRunHandle {
         ExperimentMetricLogger::new(self.clone())
     }
 
-    fn checkpoint_recorder(&self, file_name: String) -> ExperimentCheckpointer {
-        ExperimentCheckpointer::new(self.clone(), file_name)
-    }
-
     fn checkpointers(
         &self,
     ) -> (
@@ -112,9 +101,9 @@ impl ExperimentTrainingExt for crate::ExperimentRunHandle {
         ExperimentCheckpointer,
     ) {
         (
-            self.checkpoint_recorder("model".to_string()),
-            self.checkpoint_recorder("optim".to_string()),
-            self.checkpoint_recorder("scheduler".to_string()),
+            ExperimentCheckpointer::new(self.clone(), "model".to_string()),
+            ExperimentCheckpointer::new(self.clone(), "optim".to_string()),
+            ExperimentCheckpointer::new(self.clone(), "scheduler".to_string()),
         )
     }
 

--- a/crates/tracel-experiment/src/lib.rs
+++ b/crates/tracel-experiment/src/lib.rs
@@ -500,13 +500,15 @@ impl ExperimentRunHandle {
     ) -> Result<D, ExperimentError> {
         let inner = self.upgrade()?;
         inner.ensure_active()?;
+        let name_str = name.as_ref();
+        let experiment_id = experiment_id.into();
         let artifact = inner
             .reader
-            .load_artifact_raw(experiment_id.into(), name.as_ref())
+            .load_artifact_raw(experiment_id, name_str)
             .map_err(|e| {
                 ExperimentError::with_source(
                     ExperimentErrorKind::Artifact,
-                    format!("Failed to load artifact bundle for {}", name.as_ref()),
+                    format!("Failed to load artifact bundle for {name_str}"),
                     e,
                 )
             })?;
@@ -514,7 +516,7 @@ impl ExperimentRunHandle {
         D::decode(&artifact.bundle, settings).map_err(|e| {
             ExperimentError::with_source(
                 ExperimentErrorKind::Artifact,
-                format!("Failed to decode artifact: {}", name.as_ref()),
+                format!("Failed to decode artifact: {name_str}"),
                 e,
             )
         })


### PR DESCRIPTION
Migrate `ExperimentCheckpointRecorder` from Burn's `Recorder`/`Record-based `API to the new `Checkpoint`/`Checkpointer` trait API : 

- Rename `ExperimentCheckpointRecorder` to `ExperimentCheckpointer` and implement `Checkpointer<C: Checkpoint>` instead of `Recorder`/`FileRecorder`
- Replace `NamedMpkBytesRecorder` serialization with `Checkpoint::checkpoint_into_bytes` / `checkpoint_from_bytes`
- Store a `file_name` per checkpointer with epoch-based paths (`{name}-{epoch}.bpk`)
- Add `checkpointers()` convenience method returning the 3 checkpointers needed for supervised training (model, optimizer, scheduler)
- Update `checkpoint_recorder()` to accept a `file_name` parameter
- Update Burn dependency rev and clean up unused imports