### PR TITLE
fix: give a transfer a timeout drawn from the size it moves

### DIFF
--- a/crates/tracel-artifact/src/download.rs
+++ b/crates/tracel-artifact/src/download.rs
@@ -107,12 +107,13 @@ pub fn download_artifacts_to_sink_with_client_and_observer<
             return Err(DownloadError::Cancelled { rel_path });
         }
 
-        let reader = client
-            .get_reader(&file.url)
-            .map_err(|e| DownloadError::Transfer {
-                rel_path: rel_path.clone(),
-                source: e,
-            })?;
+        let reader =
+            client
+                .get_reader(&file.url, file.size_bytes)
+                .map_err(|e| DownloadError::Transfer {
+                    rel_path: rel_path.clone(),
+                    source: e,
+                })?;
         if observer.is_cancelled() {
             return Err(DownloadError::Cancelled { rel_path });
         }
@@ -374,7 +375,11 @@ mod tests {
             Ok(())
         }
 
-        fn get_reader(&self, url: &str) -> Result<Box<dyn Read + Send>, TransferError> {
+        fn get_reader(
+            &self,
+            url: &str,
+            _expected_size_bytes: Option<u64>,
+        ) -> Result<Box<dyn Read + Send>, TransferError> {
             let bytes = self
                 .files
                 .get(url)
@@ -788,7 +793,11 @@ mod tests {
             unreachable!("the cancellation test only downloads")
         }
 
-        fn get_reader(&self, _url: &str) -> Result<Box<dyn Read + Send>, TransferError> {
+        fn get_reader(
+            &self,
+            _url: &str,
+            _expected_size_bytes: Option<u64>,
+        ) -> Result<Box<dyn Read + Send>, TransferError> {
             Ok(Box::new(ChunkedReader {
                 bytes: Arc::clone(&self.bytes),
                 consumed: Arc::clone(&self.consumed),

--- a/crates/tracel-artifact/src/transfer.rs
+++ b/crates/tracel-artifact/src/transfer.rs
@@ -1,4 +1,37 @@
 use std::io::Read;
+use std::time::Duration;
+
+const TRANSFER_SECONDS_ALLOWED_PER_MEGABYTE: u64 = 10;
+
+const MINIMUN_TRANSFER_TIMEOUT: Duration = Duration::from_secs(60);
+
+const CONNECT_TIMEOUT: Duration = Duration::from_secs(30);
+
+fn timeout_worth_allowing_a_transfer_of(size_bytes: Option<u64>) -> Duration {
+    const BYTES_PER_MEGABYTE: u64 = 1024 * 1024;
+
+    let Some(size_bytes) = size_bytes else {
+        return Duration::from_secs(60 * 60);
+    };
+
+    let megabytes = size_bytes.div_ceil(BYTES_PER_MEGABYTE);
+    let allowed =
+        Duration::from_secs(megabytes.saturating_mul(TRANSFER_SECONDS_ALLOWED_PER_MEGABYTE));
+
+    allowed.max(MINIMUN_TRANSFER_TIMEOUT)
+}
+
+fn transport_failure(error: &dyn std::error::Error) -> TransferError {
+    let mut described = error.to_string();
+    let mut source = error.source();
+    while let Some(cause) = source {
+        described.push_str(": ");
+        described.push_str(&cause.to_string());
+        source = cause.source();
+    }
+
+    TransferError::Transport(described)
+}
 
 /// Watches a transfer as it runs, and can stop it.
 ///
@@ -71,7 +104,15 @@ pub trait FileTransferClient: Clone + Send + Sync + 'static {
     ) -> Result<(), TransferError>;
 
     /// Download data from the given URL as a reader.
-    fn get_reader(&self, url: &str) -> Result<Box<dyn Read + Send>, TransferError>;
+    ///
+    /// `expected_size_bytes` is what the manifest announced, where one did, so
+    /// that an implementation can give a large download the time it needs. It is
+    /// absent for an artifact published without a manifest.
+    fn get_reader(
+        &self,
+        url: &str,
+        expected_size_bytes: Option<u64>,
+    ) -> Result<Box<dyn Read + Send>, TransferError>;
 }
 
 /// Reqwest-based transfer client.
@@ -81,10 +122,18 @@ pub struct ReqwestTransferClient {
 }
 
 impl ReqwestTransferClient {
+    /// A transfer is one request whose duration is set by the caller's
+    /// bandwidth, so the deadline is set per request from the size being moved
+    /// rather than once here. Reqwest's own default is 30 seconds, which no
+    /// model larger than a few megabytes survives.
     pub fn new() -> Self {
-        Self {
-            http: reqwest::blocking::Client::new(),
-        }
+        let http = reqwest::blocking::Client::builder()
+            .timeout(None)
+            .connect_timeout(CONNECT_TIMEOUT)
+            .build()
+            .expect("failed to build the HTTP transfer client");
+
+        Self { http }
     }
 
     pub fn with_client(http: reqwest::blocking::Client) -> Self {
@@ -109,29 +158,35 @@ impl FileTransferClient for ReqwestTransferClient {
         let response = self
             .http
             .put(url)
+            .timeout(timeout_worth_allowing_a_transfer_of(Some(size_bytes)))
             .body(body)
             .send()
-            .map_err(|e| TransferError::Transport(e.to_string()))?;
+            .map_err(|error| transport_failure(&error))?;
 
         if !response.status().is_success() {
-            return Err(TransferError::Transport(
-                response.error_for_status().err().unwrap().to_string(),
+            return Err(transport_failure(
+                &response.error_for_status().err().unwrap(),
             ));
         }
 
         Ok(())
     }
 
-    fn get_reader(&self, url: &str) -> Result<Box<dyn Read + Send>, TransferError> {
+    fn get_reader(
+        &self,
+        url: &str,
+        expected_size_bytes: Option<u64>,
+    ) -> Result<Box<dyn Read + Send>, TransferError> {
         let response = self
             .http
             .get(url)
+            .timeout(timeout_worth_allowing_a_transfer_of(expected_size_bytes))
             .send()
-            .map_err(|e| TransferError::Transport(e.to_string()))?;
+            .map_err(|error| transport_failure(&error))?;
 
         if !response.status().is_success() {
-            return Err(TransferError::Transport(
-                response.error_for_status().err().unwrap().to_string(),
+            return Err(transport_failure(
+                &response.error_for_status().err().unwrap(),
             ));
         }
 

--- a/crates/tracel-artifact/src/transfer.rs
+++ b/crates/tracel-artifact/src/transfer.rs
@@ -3,7 +3,7 @@ use std::time::Duration;
 
 const TRANSFER_SECONDS_ALLOWED_PER_MEGABYTE: u64 = 10;
 
-const MINIMUN_TRANSFER_TIMEOUT: Duration = Duration::from_secs(60);
+const MINIMUM_TRANSFER_TIMEOUT: Duration = Duration::from_secs(60);
 
 const CONNECT_TIMEOUT: Duration = Duration::from_secs(30);
 
@@ -18,7 +18,7 @@ fn timeout_worth_allowing_a_transfer_of(size_bytes: Option<u64>) -> Duration {
     let allowed =
         Duration::from_secs(megabytes.saturating_mul(TRANSFER_SECONDS_ALLOWED_PER_MEGABYTE));
 
-    allowed.max(MINIMUN_TRANSFER_TIMEOUT)
+    allowed.max(MINIMUM_TRANSFER_TIMEOUT)
 }
 
 fn transport_failure(error: &dyn std::error::Error) -> TransferError {

--- a/crates/tracel-artifact/src/upload.rs
+++ b/crates/tracel-artifact/src/upload.rs
@@ -242,7 +242,11 @@ mod tests {
             Ok(())
         }
 
-        fn get_reader(&self, _url: &str) -> Result<Box<dyn Read + Send>, TransferError> {
+        fn get_reader(
+            &self,
+            _url: &str,
+            _expected_size_bytes: Option<u64>,
+        ) -> Result<Box<dyn Read + Send>, TransferError> {
             Err(TransferError::Transport(
                 "get_reader should not be used in upload tests".to_string(),
             ))

--- a/crates/tracel-console/src/models.rs
+++ b/crates/tracel-console/src/models.rs
@@ -313,7 +313,7 @@ impl VersionFileSource for ConsoleVersionFileSource {
 
     fn open(&self, _canonical_path: &str) -> Result<VersionFileReader, ModelsError> {
         self.transfer_client
-            .get_reader(&self.url)
+            .get_reader(&self.url, Some(self.file.size_bytes))
             .map_err(|error| ModelsError::other(ConsoleError::Transport(error.to_string())))
     }
 }

--- a/crates/tracel-datasets/src/handle.rs
+++ b/crates/tracel-datasets/src/handle.rs
@@ -312,11 +312,6 @@ mod tests {
         );
     }
 
-    /// What one read moves is the caller's judgement, not the version's.
-    ///
-    /// A dataset of small examples pays a round trip per sixty-four items for
-    /// nothing, and one of large examples cannot afford even that; a default
-    /// with no way past it makes one of the two wrong on every dataset.
     #[test]
     fn a_caller_can_say_how_many_items_one_read_asks_for() {
         let ops = Arc::new(FakeOps::new());

--- a/crates/tracel-datasets/src/handle.rs
+++ b/crates/tracel-datasets/src/handle.rs
@@ -7,12 +7,7 @@ use serde::de::DeserializeOwned;
 use crate::{DatasetOps, DatasetVersion, DatasetsError, Item};
 
 /// Items [`Items`] reads per request where the caller does not say.
-///
-/// An item carries its whole example payload, so the size of a read is the
-/// dataset's own rather than the SDK's: sixty-four keeps one response inside
-/// what a connection settles in for a version of large examples, and a caller
-/// whose items are small raises it with [`Items::with_items_per_read`].
-pub const ITEMS_PER_READ: u64 = 64;
+const ITEMS_PER_READ: u64 = 64;
 
 /// One item of a dataset version, with its annotation decoded into the caller's type.
 #[derive(Clone, Debug, PartialEq)]

--- a/crates/tracel-datasets/src/handle.rs
+++ b/crates/tracel-datasets/src/handle.rs
@@ -172,12 +172,7 @@ pub struct Items<A> {
 }
 
 impl<A> Items<A> {
-    /// Asks for `items` per read rather than [`ITEMS_PER_READ`].
-    ///
-    /// How much one read moves is the caller's to judge: it knows how large its
-    /// examples are and what its connection tolerates, and neither is
-    /// something the version announces. Zero would ask for nothing and leave
-    /// the cursor where it was, so it is read as one.
+    /// Asks for `items` per read.
     pub fn with_items_per_read(mut self, items: u64) -> Self {
         self.items_per_read = items.max(1);
         self

--- a/crates/tracel-datasets/src/handle.rs
+++ b/crates/tracel-datasets/src/handle.rs
@@ -6,8 +6,13 @@ use serde::de::DeserializeOwned;
 
 use crate::{DatasetOps, DatasetVersion, DatasetsError, Item};
 
-/// Items read per batch by [`Items`].
-const BATCH: u64 = 256;
+/// Items [`Items`] reads per request where the caller does not say.
+///
+/// An item carries its whole example payload, so the size of a read is the
+/// dataset's own rather than the SDK's: sixty-four keeps one response inside
+/// what a connection settles in for a version of large examples, and a caller
+/// whose items are small raises it with [`Items::with_items_per_read`].
+pub const ITEMS_PER_READ: u64 = 64;
 
 /// One item of a dataset version, with its annotation decoded into the caller's type.
 #[derive(Clone, Debug, PartialEq)]
@@ -119,11 +124,15 @@ where
     }
 
     /// Iterates from `from` to the end of the version, reading in batches.
+    ///
+    /// Each read asks for [`ITEMS_PER_READ`] items unless
+    /// [`Items::with_items_per_read`] says otherwise.
     pub fn iter(&self, from: u64) -> Items<A> {
         Items {
             handle: self.clone(),
             next: from,
             buffer: VecDeque::new(),
+            items_per_read: ITEMS_PER_READ,
         }
     }
 
@@ -164,6 +173,20 @@ pub struct Items<A> {
     handle: DatasetHandle<A>,
     next: u64,
     buffer: VecDeque<DatasetItem<A>>,
+    items_per_read: u64,
+}
+
+impl<A> Items<A> {
+    /// Asks for `items` per read rather than [`ITEMS_PER_READ`].
+    ///
+    /// How much one read moves is the caller's to judge: it knows how large its
+    /// examples are and what its connection tolerates, and neither is
+    /// something the version announces. Zero would ask for nothing and leave
+    /// the cursor where it was, so it is read as one.
+    pub fn with_items_per_read(mut self, items: u64) -> Self {
+        self.items_per_read = items.max(1);
+        self
+    }
 }
 
 impl<A> Iterator for Items<A>
@@ -180,7 +203,7 @@ where
                 return None;
             }
 
-            let end = (self.next + BATCH).min(item_count);
+            let end = (self.next + self.items_per_read).min(item_count);
             let indexes: Vec<u64> = (self.next..end).collect();
 
             match self.handle.items(&indexes) {
@@ -282,7 +305,48 @@ mod tests {
         let items: Vec<_> = data.iter(0).collect::<Result<Vec<_>, _>>().unwrap();
 
         assert_eq!(items.len(), 600);
-        assert_eq!(ops.reads(), 3, "600 items over a 256 batch");
+        assert_eq!(
+            ops.reads(),
+            10,
+            "600 items over the default 64 a read asks for"
+        );
+    }
+
+    /// What one read moves is the caller's judgement, not the version's.
+    ///
+    /// A dataset of small examples pays a round trip per sixty-four items for
+    /// nothing, and one of large examples cannot afford even that; a default
+    /// with no way past it makes one of the two wrong on every dataset.
+    #[test]
+    fn a_caller_can_say_how_many_items_one_read_asks_for() {
+        let ops = Arc::new(FakeOps::new());
+        let data = handle(ops.clone(), 600);
+
+        let items: Vec<_> = data
+            .iter(0)
+            .with_items_per_read(256)
+            .collect::<Result<Vec<_>, _>>()
+            .unwrap();
+
+        assert_eq!(items.len(), 600);
+        assert_eq!(ops.reads(), 3, "600 items over the 256 asked for");
+    }
+
+    /// A batch of zero would ask for no indexes, get none back, and leave the
+    /// cursor where it was — the iterator would never end.
+    #[test]
+    fn a_read_of_zero_items_is_read_as_one_rather_than_never_advancing() {
+        let ops = Arc::new(FakeOps::new());
+        let data = handle(ops.clone(), 5);
+
+        let items: Vec<_> = data
+            .iter(0)
+            .with_items_per_read(0)
+            .collect::<Result<Vec<_>, _>>()
+            .unwrap();
+
+        assert_eq!(items.len(), 5);
+        assert_eq!(ops.reads(), 5, "one item per read");
     }
 
     #[test]

--- a/crates/tracel-datasets/src/lib.rs
+++ b/crates/tracel-datasets/src/lib.rs
@@ -18,5 +18,5 @@ mod test_support;
 pub use datasets::{Datasets, VersionDraft};
 pub use domain::{Dataset, DatasetVersion, Item, NewItem, VersionId, VersionSpec};
 pub use error::DatasetsError;
-pub use handle::{DatasetHandle, DatasetItem, Items};
+pub use handle::{DatasetHandle, DatasetItem, ITEMS_PER_READ, Items};
 pub use ops::{DatasetOps, Publication};

--- a/crates/tracel-datasets/src/lib.rs
+++ b/crates/tracel-datasets/src/lib.rs
@@ -18,5 +18,5 @@ mod test_support;
 pub use datasets::{Datasets, VersionDraft};
 pub use domain::{Dataset, DatasetVersion, Item, NewItem, VersionId, VersionSpec};
 pub use error::DatasetsError;
-pub use handle::{DatasetHandle, DatasetItem, ITEMS_PER_READ, Items};
+pub use handle::{DatasetHandle, DatasetItem, Items};
 pub use ops::{DatasetOps, Publication};

--- a/crates/tracel-station/src/models.rs
+++ b/crates/tracel-station/src/models.rs
@@ -142,7 +142,7 @@ impl VersionFileSource for StationVersionFileSource {
 
     fn open(&self, _canonical_path: &str) -> Result<VersionFileReader, ModelsError> {
         self.transfer_client
-            .get_reader(&self.url)
+            .get_reader(&self.url, Some(self.file.size_bytes))
             .map_err(|error| ModelsError::other(StationError::Transport(error.to_string())))
     }
 }


### PR DESCRIPTION
## The bug

Publishing a 68 MB model to the console fails:

```
error: publishing failed
  caused by: transfer error for part 1 of 1 for my-model.bpk:
             Transport error: error sending request for url (https://s3...)
```

`ReqwestTransferClient` was built with `reqwest::blocking::Client::new()`, whose default is a **30 second** total request timeout. A 68 MB upload needs better than 18 Mbit/s sustained to fit in that, so anything short of a fast office link fails. The model was created on the console and its version left with no bytes in S3.

Every S3 transfer in the SDK goes through that one constructor, so the same 30 seconds applied to model downloads and to experiment artifacts on both backends:

| Path | Client |
| --- | --- |
| Console model publish | `tracel-console/src/console.rs:45` |
| Console model download | same |
| Station model download | `tracel-station/src/station.rs:28` |
| Experiment artifacts, both backends | `upload.rs:87`, `download.rs:79` |

## The fix

A transfer is one request whose duration is set by the caller's bandwidth, so no fixed timeout serves it. The deadline is now computed per request from the payload: **ten seconds per megabyte, with a sixty second floor**.

| Payload | Allowance | Slowest link that still finishes |
| --- | --- | --- |
| 5 MB | 60 s (floor) | trivial |
| 68 MB | 11 min 20 s | 0.8 Mbit/s |
| 500 MB | 83 min | 0.8 Mbit/s |